### PR TITLE
fix(make): profile images built empty (make-vs-shell $ in image target)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ image: ## Build a combined image with all extensions
 	{ \
 		echo "FROM postgres:$(PG)"; \
 		for ext in $(EXTENSIONS); do \
-			ver=$(./scripts/ext-version.sh "$ext" "$(PG)"); \
+			ver=$$(./scripts/ext-version.sh "$$ext" "$(PG)"); \
 			[ -z "$$ver" ] && continue; \
 			total=$$((total + 1)); \
 			if [ "$(REGISTRY)" = "local" ]; then \
@@ -271,7 +271,7 @@ image: ## Build a combined image with all extensions
 		fi; \
 		preloads=""; \
 		for ext in $(EXTENSIONS); do \
-			ver=$(./scripts/ext-version.sh "$ext" "$(PG)"); \
+			ver=$$(./scripts/ext-version.sh "$$ext" "$(PG)"); \
 			[ -z "$$ver" ] && continue; \
 			if [ "$(REGISTRY)" = "local" ]; then \
 				docker image inspect "$(REGISTRY)/$(PREFIX)-$$ext:$(PG)" >/dev/null 2>&1 || continue; \
@@ -283,7 +283,7 @@ image: ## Build a combined image with all extensions
 		done; \
 		[ -n "$$preloads" ] && echo "RUN echo \"shared_preload_libraries = '$$preloads'\" >> /usr/share/postgresql/postgresql.conf.sample"; \
 		for ext in $(EXTENSIONS); do \
-			ver=$(./scripts/ext-version.sh "$ext" "$(PG)"); \
+			ver=$$(./scripts/ext-version.sh "$$ext" "$(PG)"); \
 			[ -z "$$ver" ] && continue; \
 			if [ "$(REGISTRY)" = "local" ]; then \
 				docker image inspect "$(REGISTRY)/$(PREFIX)-$$ext:$(PG)" >/dev/null 2>&1 || continue; \
@@ -302,7 +302,7 @@ image: ## Build a combined image with all extensions
 		fi; \
 		companions=""; \
 		for ext in $(EXTENSIONS); do \
-			ver=$(./scripts/ext-version.sh "$ext" "$(PG)"); \
+			ver=$$(./scripts/ext-version.sh "$$ext" "$(PG)"); \
 			[ -z "$$ver" ] && continue; \
 			if [ "$(REGISTRY)" = "local" ]; then \
 				docker image inspect "$(REGISTRY)/$(PREFIX)-$$ext:$(PG)" >/dev/null 2>&1 || continue; \


### PR DESCRIPTION
## Problem
The `pglayers-azure` / `pglayers-full` profile images published by CI ship
**base-only** — no extensions. Inspecting them:
- `org.pglayers.extensions.count = 0`, `included = ""`
- ~15 layers, ~same size as bare `postgres:<pg>`

## Root cause
The `image` target's four extension loops resolved the version with:
```make
ver=$(./scripts/ext-version.sh "$ext" "$(PG)")
```
That is **make** expansion, not shell: make expands `$(...)` (no such function
→ empty) and `$ext` (undefined make variable → empty), so `ver` was always
empty and `[ -z "$ver" ] && continue` skipped **every** extension. (Compare the
correct pattern at lines 118 / 486 which use `$$(...)` and `$$ext`.)

## Fix
Use shell syntax in all four loops (FROM/COPY, `shared_preload_libraries`,
`PG_CONF`, `COMPANION_CMD`):
```make
ver=$$(./scripts/ext-version.sh "$$ext" "$(PG)")
```
`$(PG)` stays a make variable (correct).

## Verification
A 2-extension test profile now reports `Included 2/2 extensions` (`count=2`)
instead of `0/0`. After merge, the `profile-images` CI job will rebuild the
azure/full images with their extensions actually included.