### PR TITLE
fix(pgsodium): harden libsodium download against flaky DNS

### DIFF
--- a/extensions/pgsodium/Dockerfile
+++ b/extensions/pgsodium/Dockerfile
@@ -14,11 +14,25 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     build-essential git ca-certificates curl patchelf \
     postgresql-server-dev-${PG_MAJOR}
 
-# Build libsodium from source (distro version too old for pgsodium 3.1.11+)
-RUN curl -fsSL "https://download.libsodium.org/libsodium/releases/libsodium-${LIBSODIUM_VERSION}.tar.gz" \
-    | tar xz -C /tmp \
-    && cd /tmp/libsodium-${LIBSODIUM_VERSION} \
-    && ./configure --prefix=/usr && make -j"$(nproc)" && make install
+# Build libsodium from source (distro version too old for pgsodium 3.1.11+).
+# Fetch from the GitHub release mirror first, falling back to the canonical
+# download.libsodium.org host (which intermittently fails DNS in CI), each with
+# retries.
+RUN set -eux; \
+    for url in \
+        "https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}-RELEASE/libsodium-${LIBSODIUM_VERSION}.tar.gz" \
+        "https://download.libsodium.org/libsodium/releases/libsodium-${LIBSODIUM_VERSION}.tar.gz" \
+    ; do \
+        if curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+            -o /tmp/libsodium.tar.gz "$url"; then \
+            break; \
+        fi; \
+    done; \
+    test -s /tmp/libsodium.tar.gz; \
+    tar xz -C /tmp -f /tmp/libsodium.tar.gz; \
+    cd /tmp/libsodium-${LIBSODIUM_VERSION}; \
+    ./configure --prefix=/usr && make -j"$(nproc)" && make install; \
+    rm -f /tmp/libsodium.tar.gz
 
 RUN git clone --branch ${EXT_VERSION} --depth 1 \
     https://github.com/michelp/pgsodium.git /tmp/ext


### PR DESCRIPTION
## Problem

CI intermittently fails building `pgsodium` with:

```
curl: (6) Could not resolve host: download.libsodium.org
```

This flake broke the first CI run on #39 (documentdb bump), which had nothing to do with pgsodium — the `Test PG 18` job just happened to rebuild pgsodium and hit a transient DNS failure on the canonical `download.libsodium.org` host. A re-run passed, confirming it's non-deterministic infrastructure flakiness rather than a real regression.

## Fix

Harden the libsodium source fetch in `extensions/pgsodium/Dockerfile`:

- **GitHub release mirror first** (`github.com/jedisct1/libsodium/releases/...`), falling back to the canonical `download.libsodium.org`.
- **`--retry 5 --retry-all-errors --retry-delay 2`** — `--retry-all-errors` is the key flag: plain `--retry` does **not** retry on curl's DNS-resolution failure (exit 6), which is exactly the error we hit.
- Download to a file, assert it's non-empty (`test -s`), then extract — so a partial/failed download fails loudly instead of feeding a truncated tarball to `tar`.

No version change; `LIBSODIUM_VERSION` stays `1.0.22`. The GitHub asset naming (`${VERSION}-RELEASE` tag → `libsodium-${VERSION}.tar.gz`) matches upstream releases.

## Validation

- `make build EXT=pgsodium PG=18 REGISTRY=local` — passes (builds via the GitHub mirror; isolated-layout normalizer mangles/`$ORIGIN`-rpaths `libsodium.so.26` as before).

> Split out of #39 to keep that PR scoped to the DocumentDB bump.