### PR TITLE
ci: build-once → test → promote pipeline (fix PG18 recompute/disk deadlock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,29 @@
 name: CI
 
-# Unified pipeline: build -> test -> compose profiles, all from freshly built
-# layers, plus publish on merge. Replaces the former build-push.yml, test.yml,
-# test-k8s.yml and test-cnpg.yml.
+# Build-once pipeline.
 #
-#   pull_request  -> matrix + checks + test + test-profile + integration
-#                    (everything built/composed locally, nothing pushed)
-#   push to main  -> the same verification, then build + manifest +
-#                    profile-images publish jobs (gated on the tests passing)
-#   schedule      -> weekly safety-net full rebuild + publish
-#   workflow_dispatch -> targeted rebuild/publish
+# Layers are compiled exactly ONCE, on the pull request (or schedule/dispatch),
+# by the `build` job, which pushes immutable per-commit staging tags:
+#     source ext (per-arch):  pgx-<ext>:<pg>-<version>-<arch>
+#     apt ext (multi-arch):   pgx-<ext>:<pg>-<version>
+# The test / test-profile / integration jobs PULL those images and validate
+# them -- they never recompile. On merge to main the `promote` jobs retag the
+# already-built, already-tested per-arch images into the public multi-arch
+# :<pg> / :<pg>-<version> manifests and compose the profile images -- again
+# without rebuilding.
 #
-# Composition never pulls a stale layer: scripts/ci-prepare-images.sh rebuilds
-# changed extensions from source and pulls only unchanged ones, so the test
-# and profile jobs always see the current code.
+#   pull_request (same-repo) -> matrix + checks + build(+push staging) +
+#                               test + test-profile + integration
+#   pull_request (fork)      -> same, but `build` is skipped (forks cannot push
+#                               to GHCR); the test jobs compile changed layers
+#                               locally instead. Nothing is published.
+#   push to main             -> matrix + promote only. Reuses the staging images
+#                               the PR already built and tested; no rebuild.
+#   schedule / dispatch      -> full (or targeted) build + test + promote.
+#
+# scripts/ci-prepare-images.sh is the single source of truth for assembling the
+# local/ image set the test jobs compose from (pull staging/published, else
+# build from source as a fork fallback).
 
 on:
   pull_request:
@@ -64,14 +74,15 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Plan: what changed, what to test, what to publish.
+  # Plan: what changed, what to build/publish, what to test.
   # ---------------------------------------------------------------------------
   matrix:
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.set.outputs.changed }}       # ext-level changes (test jobs rebuild these)
-      build: ${{ steps.set.outputs.build }}           # publish build matrix (per-arch)
-      extensions: ${{ steps.set.outputs.extensions }} # publish manifest matrix
+      changed: ${{ steps.set.outputs.changed }}       # exts changed in this run
+      build_native: ${{ steps.set.outputs.build_native }} # source builds (per-arch)
+      build_apt: ${{ steps.set.outputs.build_apt }}    # apt builds (multi-arch)
+      extensions: ${{ steps.set.outputs.extensions }} # promote/manifest matrix
       publish: ${{ steps.set.outputs.publish }}        # 'true' on push/schedule/dispatch
       test_pgs: ${{ steps.set.outputs.test_pgs }}      # PG majors the test jobs cover
     steps:
@@ -113,22 +124,23 @@ jobs:
             test_changed=$(echo "$test_changed" | tr ' ' '\n' | sed '/^$/d' | sort -u | tr '\n' ' ')
           fi
 
-          # --- publish scope: build+push targeted (test_changed) unless an
-          #     infra change forces a full rebuild ---
+          # --- full-rebuild triggers ---
           build_all=false
           case "$event" in
             schedule) build_all=true ;;
             workflow_dispatch) [ -z "$ext_filter" ] && build_all=true ;;
           esac
-          # A change to the build/compose plumbing can affect every layer.
-          if [ "$event" = "push" ] && \
+          # A change to the build/compose plumbing can affect every layer, so a
+          # PR (or merge) that touches it exercises a full rebuild.
+          if { [ "$event" = "push" ] || [ "$event" = "pull_request" ]; } && \
              git diff --name-only HEAD~1 \
                | grep -qE '^(\.github/workflows/ci\.yml|Makefile|scripts/)'; then
             build_all=true
           fi
 
           extensions="[]"
-          build="[]"
+          build_native="[]"
+          build_apt="[]"
           for ext_dir in extensions/*/; do
             ext="$(basename "$ext_dir")"
             [ -n "$ext_filter" ] && [ "$ext" != "$ext_filter" ] && continue
@@ -169,26 +181,25 @@ jobs:
                 '. + [{"extension": $ext, "pg": $pg, "version": $ver, "apt_package": $apt, "dockerfile": $df}]')
               if [ -z "$APT_PACKAGE" ]; then
                 for arch in amd64 arm64; do
-                  build=$(echo "$build" | jq -c \
+                  build_native=$(echo "$build_native" | jq -c \
                     --arg ext "$ext" --arg pg "$pg" --arg ver "$ver" --arg arch "$arch" \
                     --arg vcpkg "${VCPKG_VERSION:-}" --arg df "$dockerfile" \
-                    '. + [{"extension": $ext, "pg": $pg, "version": $ver, "arch": $arch, "native": true, "vcpkg_version": $vcpkg, "apt_package": "", "dockerfile": $df}]')
+                    '. + [{"extension": $ext, "pg": $pg, "version": $ver, "arch": $arch, "vcpkg_version": $vcpkg, "dockerfile": $df}]')
                 done
               else
-                build=$(echo "$build" | jq -c \
+                build_apt=$(echo "$build_apt" | jq -c \
                   --arg ext "$ext" --arg pg "$pg" --arg ver "$ver" \
                   --arg apt "$APT_PACKAGE" --arg df "$dockerfile" \
-                  '. + [{"extension": $ext, "pg": $pg, "version": $ver, "arch": "all", "native": false, "apt_package": $apt, "dockerfile": $df}]')
+                  '. + [{"extension": $ext, "pg": $pg, "version": $ver, "apt_package": $apt, "dockerfile": $df}]')
               fi
             done
           done
 
-          # PG majors to test: PRs cover 17+18 (classic + isolated); push and
-          # scheduled runs add 19 (beta, non-blocking).
+          # PG majors to test. The PR is now the sole verification gate, so it
+          # covers every supported major (19 stays non-blocking via
+          # continue-on-error in the test jobs).
           if [ -n "$pg_filter" ]; then
             test_pgs="[\"$pg_filter\"]"
-          elif [ "$event" = "pull_request" ]; then
-            test_pgs='["17","18"]'
           else
             test_pgs='["17","18","19"]'
           fi
@@ -196,9 +207,10 @@ jobs:
           publish='false'
           case "$event" in push|schedule|workflow_dispatch) publish='true' ;; esac
 
-          # What the test jobs rebuild from source (vs pull). This must mirror
-          # the publish scope so a full/targeted rebuild is verified against the
-          # freshly built layers, not stale pulled ones (e.g. the weekly cron).
+          # What the test jobs treat as "changed" (pull freshly-built staging /
+          # build-from-source fallback) vs "unchanged" (pull published). Mirrors
+          # the build scope so a full/targeted rebuild is verified against the
+          # freshly built layers, not stale published ones.
           if [ "$build_all" = "true" ]; then
             changed_out="$(for d in extensions/*/; do basename "$d"; done | tr '\n' ' ')"
           elif [ "$event" = "workflow_dispatch" ] && [ -n "$ext_filter" ]; then
@@ -209,14 +221,15 @@ jobs:
 
           {
             echo "changed=$changed_out"
-            echo "build=$build"
+            echo "build_native=$build_native"
+            echo "build_apt=$build_apt"
             echo "extensions=$extensions"
             echo "publish=$publish"
             echo "test_pgs=$test_pgs"
           } >> "$GITHUB_OUTPUT"
           echo "changed: [$changed_out]"
           echo "publish: $publish | test_pgs: $test_pgs"
-          echo "publish build jobs: $(echo "$build" | jq length)"
+          echo "native build jobs: $(echo "$build_native" | jq length) | apt build jobs: $(echo "$build_apt" | jq length) | manifest jobs: $(echo "$extensions" | jq length)"
 
   # ---------------------------------------------------------------------------
   # Static checks (profiles + licenses), once per run.
@@ -231,11 +244,130 @@ jobs:
         run: make check-licenses
 
   # ---------------------------------------------------------------------------
+  # Build each layer ONCE and push an immutable staging tag. Runs on the PR
+  # (same-repo only -- forks cannot push to GHCR), schedule and dispatch; NOT on
+  # push-to-main (the merge reuses these images via `promote`).
+  #
+  # Split into two jobs so neither matrix approaches GitHub's 256-job limit on a
+  # full rebuild: source extensions build natively per-arch (no QEMU); APT
+  # extensions build multi-arch in one shot.
+  # ---------------------------------------------------------------------------
+  build-native:
+    needs: matrix
+    if: >-
+      ${{ github.event_name != 'push'
+          && (github.event_name != 'pull_request'
+              || github.event.pull_request.head.repo.full_name == github.repository)
+          && fromJson(needs.matrix.outputs.build_native)[0] != null }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.matrix.outputs.build_native) }}
+    continue-on-error: ${{ matrix.pg == '19' }}
+    name: Build (${{ matrix.extension }}, ${{ matrix.pg }}, ${{ matrix.arch }})
+    steps:
+      - uses: actions/checkout@v7
+      - name: Free disk space
+        run: ./scripts/ci-free-disk.sh
+      - uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push per-arch staging image
+        uses: docker/build-push-action@v7
+        with:
+          context: extensions/${{ matrix.extension }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/${{ matrix.arch }}
+          build-args: |
+            PG_MAJOR=${{ matrix.pg }}
+            PG_TAG=${{ matrix.pg == '19' && '19beta1' || matrix.pg }}
+            EXT_VERSION=${{ matrix.version }}
+            EXT_NAME=${{ matrix.extension }}
+            LAYOUT=${{ matrix.pg >= 18 && 'isolated' || 'classic' }}
+          push: true
+          # Immutable per-version, per-arch staging tag -- never the public :<pg>.
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:${{ matrix.pg }}-${{ matrix.version }}-${{ matrix.arch }}
+          cache-from: |
+            type=gha,scope=${{ matrix.extension }}-${{ matrix.pg }}-${{ matrix.arch }}
+            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-${{ matrix.arch }}
+            ${{ matrix.extension == 'plv8' && format('type=registry,ref={0}/{1}/plv8-v8:{2}', env.REGISTRY, github.repository_owner, matrix.version) || '' }}
+            ${{ matrix.vcpkg_version != '' && format('type=registry,ref={0}/{1}/pg-lake-vcpkg:{2}', env.REGISTRY, github.repository_owner, matrix.vcpkg_version) || '' }}
+          cache-to: |
+            type=gha,mode=max,scope=${{ matrix.extension }}-${{ matrix.pg }}-${{ matrix.arch }}
+            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-${{ matrix.arch }},mode=max
+
+  build-apt:
+    needs: matrix
+    if: >-
+      ${{ github.event_name != 'push'
+          && (github.event_name != 'pull_request'
+              || github.event.pull_request.head.repo.full_name == github.repository)
+          && fromJson(needs.matrix.outputs.build_apt)[0] != null }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.matrix.outputs.build_apt) }}
+    continue-on-error: ${{ matrix.pg == '19' }}
+    name: Build apt (${{ matrix.extension }}, ${{ matrix.pg }})
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push multi-arch staging image
+        uses: docker/build-push-action@v7
+        with:
+          context: extensions/${{ matrix.extension }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            PG_MAJOR=${{ matrix.pg }}
+            PG_TAG=${{ matrix.pg == '19' && '19beta1' || matrix.pg }}
+            EXT_VERSION=${{ matrix.version }}
+            APT_PACKAGE=${{ matrix.apt_package }}
+            EXT_NAME=${{ matrix.extension }}
+            LAYOUT=${{ matrix.pg >= 18 && 'isolated' || 'classic' }}
+          push: true
+          # Immutable, multi-arch per-version staging tag -- never the public :<pg>.
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:${{ matrix.pg }}-${{ matrix.version }}
+          cache-from: |
+            type=gha,scope=${{ matrix.extension }}-${{ matrix.pg }}-all
+            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-all
+          cache-to: |
+            type=gha,mode=max,scope=${{ matrix.extension }}-${{ matrix.pg }}-all
+            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-all,mode=max
+
+  # ---------------------------------------------------------------------------
   # Layer + combined-image tests (collision, self-containment, cross-layer
-  # leak, CREATE EXTENSION, functional) against freshly assembled images.
+  # leak, CREATE EXTENSION, functional) against images pulled from `build`
+  # (fork PRs compile changed layers from source instead). Not run on push --
+  # the merge trusts the PR's green run and only promotes.
   # ---------------------------------------------------------------------------
   test:
-    needs: matrix
+    needs: [matrix, build-native, build-apt]
+    if: >-
+      ${{ github.event_name != 'push' && !cancelled()
+          && needs.matrix.result == 'success'
+          && (needs['build-native'].result == 'success' || needs['build-native'].result == 'skipped')
+          && (needs['build-apt'].result == 'success' || needs['build-apt'].result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -251,10 +383,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
-          docker system prune -af
-          df -h /
+        run: ./scripts/ci-free-disk.sh
       - name: Tag beta image as major version
         if: matrix.pg == '19'
         run: |
@@ -267,7 +396,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Prepare extension images (build changed, pull unchanged)
+      - name: Prepare extension images (pull staging/published, build fork changes)
         env:
           SOURCE_REGISTRY: ${{ env.REGISTRY }}/${{ github.repository_owner }}
           PREFIX: ${{ env.PREFIX }}
@@ -284,12 +413,16 @@ jobs:
         run: make test REGISTRY=local PG=${{ matrix.pg }} PG_TAG="$PG_TAG"
 
   # ---------------------------------------------------------------------------
-  # Compose the azure profile image from freshly assembled layers and run its
-  # functional test.sql suite. (The `full` profile is published, not tested,
-  # since `test` already composes/leak-checks the complete extension set.)
+  # Compose the azure profile image from the assembled layers and run its
+  # functional test.sql suite.
   # ---------------------------------------------------------------------------
   test-profile:
-    needs: matrix
+    needs: [matrix, build-native, build-apt]
+    if: >-
+      ${{ github.event_name != 'push' && !cancelled()
+          && needs.matrix.result == 'success'
+          && (needs['build-native'].result == 'success' || needs['build-native'].result == 'skipped')
+          && (needs['build-apt'].result == 'success' || needs['build-apt'].result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -305,9 +438,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
-          docker system prune -af
+        run: ./scripts/ci-free-disk.sh
       - name: Tag beta image as major version
         if: matrix.pg == '19'
         run: |
@@ -320,7 +451,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Prepare azure profile images (build changed, pull unchanged)
+      - name: Prepare azure profile images (pull staging/published, build fork changes)
         env:
           SOURCE_REGISTRY: ${{ env.REGISTRY }}/${{ github.repository_owner }}
           PREFIX: ${{ env.PREFIX }}
@@ -337,10 +468,15 @@ jobs:
           make test-image PG=${{ matrix.pg }} PROFILE=azure
 
   # ---------------------------------------------------------------------------
-  # Kubernetes ImageVolume + CloudNativePG integration (k3d, PG 18).
+  # Kubernetes (ImageVolume) + CloudNativePG integration tests, PG 18 only.
   # ---------------------------------------------------------------------------
   integration:
-    needs: matrix
+    needs: [matrix, build-native, build-apt]
+    if: >-
+      ${{ github.event_name != 'push' && !cancelled()
+          && needs.matrix.result == 'success'
+          && (needs['build-native'].result == 'success' || needs['build-native'].result == 'skipped')
+          && (needs['build-apt'].result == 'success' || needs['build-apt'].result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -361,7 +497,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Prepare test extension images (build changed, pull unchanged)
+      - name: Prepare test extension images (pull staging/published, build fork changes)
         env:
           SOURCE_REGISTRY: ${{ env.REGISTRY }}/${{ github.repository_owner }}
           PREFIX: ${{ env.PREFIX }}
@@ -374,64 +510,28 @@ jobs:
         run: make test-${{ matrix.target }} REGISTRY=local PG=18
 
   # ---------------------------------------------------------------------------
-  # Publish (push / schedule / dispatch only), gated on the tests above.
-  # Build each architecture natively (no QEMU) and push per-arch tags.
+  # Promote (publish) -- push-to-main / schedule / dispatch only. Retags the
+  # already-built, already-tested per-arch staging images into the public
+  # multi-arch manifests. NO rebuild.
+  #
+  # On push it reuses the images the PR built + tested (gated by branch
+  # protection on the PR's green run). On schedule/dispatch it runs after this
+  # run's own build+test.
   # ---------------------------------------------------------------------------
-  build:
-    needs: [matrix, checks, test, test-profile, integration]
-    if: ${{ needs.matrix.outputs.publish == 'true' && github.ref == 'refs/heads/main' && fromJson(needs.matrix.outputs.build)[0] != null }}
-    runs-on: ${{ matrix.native && (matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04') || 'ubuntu-24.04' }}
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.matrix.outputs.build) }}
-    continue-on-error: ${{ matrix.pg == '19' }}
-    name: Build (${{ matrix.extension }}, ${{ matrix.pg }}, ${{ matrix.arch }})
-    steps:
-      - uses: actions/checkout@v7
-      - name: Set up QEMU
-        if: ${{ !matrix.native }}
-        uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: extensions/${{ matrix.extension }}
-          file: ${{ matrix.dockerfile }}
-          platforms: ${{ matrix.native && format('linux/{0}', matrix.arch) || 'linux/amd64,linux/arm64' }}
-          build-args: |
-            PG_MAJOR=${{ matrix.pg }}
-            PG_TAG=${{ matrix.pg == '19' && '19beta1' || matrix.pg }}
-            EXT_VERSION=${{ matrix.version }}
-            APT_PACKAGE=${{ matrix.apt_package }}
-            EXT_NAME=${{ matrix.extension }}
-            LAYOUT=${{ matrix.pg >= 18 && 'isolated' || 'classic' }}
-          push: true
-          tags: |
-            ${{ matrix.native && format('{0}/{1}/{2}-{3}:{4}-{5}', env.REGISTRY, github.repository_owner, env.PREFIX, matrix.extension, matrix.pg, matrix.arch) || format('{0}/{1}/{2}-{3}:{4}', env.REGISTRY, github.repository_owner, env.PREFIX, matrix.extension, matrix.pg) }}
-            ${{ !matrix.native && format('{0}/{1}/{2}-{3}:{4}-{5}', env.REGISTRY, github.repository_owner, env.PREFIX, matrix.extension, matrix.pg, matrix.version) || '' }}
-          cache-from: |
-            type=gha,scope=${{ matrix.extension }}-${{ matrix.pg }}-${{ matrix.arch }}
-            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-${{ matrix.arch }}
-            ${{ matrix.extension == 'plv8' && format('type=registry,ref={0}/{1}/plv8-v8:{2}', env.REGISTRY, github.repository_owner, matrix.version) || '' }}
-            ${{ matrix.vcpkg_version != '' && format('type=registry,ref={0}/{1}/pg-lake-vcpkg:{2}', env.REGISTRY, github.repository_owner, matrix.vcpkg_version) || '' }}
-          cache-to: |
-            type=gha,mode=max,scope=${{ matrix.extension }}-${{ matrix.pg }}-${{ matrix.arch }}
-            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-${{ matrix.arch }},mode=max
-
-  # Merge per-arch images into multi-arch manifest lists (native builds only).
   manifest:
-    needs: [matrix, build]
-    if: ${{ needs.matrix.outputs.publish == 'true' && github.ref == 'refs/heads/main' && fromJson(needs.matrix.outputs.extensions)[0] != null }}
+    needs: [matrix, checks, build-native, build-apt, test, test-profile, integration]
+    if: >-
+      ${{ always() && !cancelled()
+          && needs.matrix.outputs.publish == 'true'
+          && github.ref == 'refs/heads/main'
+          && fromJson(needs.matrix.outputs.extensions)[0] != null
+          && needs.matrix.result == 'success'
+          && (needs.checks.result == 'success' || needs.checks.result == 'skipped')
+          && (needs['build-native'].result == 'success' || needs['build-native'].result == 'skipped')
+          && (needs['build-apt'].result == 'success' || needs['build-apt'].result == 'skipped')
+          && (needs.test.result == 'success' || needs.test.result == 'skipped')
+          && (needs['test-profile'].result == 'success' || needs['test-profile'].result == 'skipped')
+          && (needs.integration.result == 'success' || needs.integration.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -440,32 +540,39 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.matrix.outputs.extensions) }}
     continue-on-error: ${{ matrix.pg == '19' }}
-    name: Manifest (${{ matrix.extension }}, ${{ matrix.pg }})
+    name: Promote (${{ matrix.extension }}, ${{ matrix.pg }})
     steps:
       - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create multi-arch manifest (if per-arch images exist)
+      - name: Promote staging image to public manifests
         run: |
           IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}"
-          if docker buildx imagetools inspect "${IMAGE}:${{ matrix.pg }}-amd64" >/dev/null 2>&1 && \
-             docker buildx imagetools inspect "${IMAGE}:${{ matrix.pg }}-arm64" >/dev/null 2>&1; then
-            docker buildx imagetools create -t "${IMAGE}:${{ matrix.pg }}" \
-              "${IMAGE}:${{ matrix.pg }}-amd64" \
-              "${IMAGE}:${{ matrix.pg }}-arm64"
-            docker buildx imagetools create -t "${IMAGE}:${{ matrix.pg }}-${{ matrix.version }}" \
-              "${IMAGE}:${{ matrix.pg }}-amd64" \
-              "${IMAGE}:${{ matrix.pg }}-arm64"
+          PG="${{ matrix.pg }}"
+          VER="${{ matrix.version }}"
+          if [ -n "${{ matrix.apt_package }}" ]; then
+            # APT layers were pushed multi-arch as :<pg>-<version>; just add :<pg>.
+            docker buildx imagetools create -t "${IMAGE}:${PG}" "${IMAGE}:${PG}-${VER}"
           else
-            echo "Skipping manifest (APT-based extension, already multi-arch)"
+            # Source layers were pushed per-arch as :<pg>-<version>-<arch>; merge
+            # into the multi-arch :<pg> and :<pg>-<version> manifests.
+            docker buildx imagetools create \
+              -t "${IMAGE}:${PG}" \
+              -t "${IMAGE}:${PG}-${VER}" \
+              "${IMAGE}:${PG}-${VER}-amd64" \
+              "${IMAGE}:${PG}-${VER}-arm64"
           fi
 
-  # Compose and push profile images from the freshly published layers.
+  # Compose and push profile images from the freshly promoted layers.
   profile-images:
-    needs: [matrix, checks, test, test-profile, integration, build, manifest]
-    if: ${{ always() && !cancelled() && needs.matrix.outputs.publish == 'true' && github.ref == 'refs/heads/main' && needs.checks.result == 'success' && needs.test.result == 'success' && needs['test-profile'].result == 'success' && needs.integration.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.manifest.result == 'success' || needs.manifest.result == 'skipped') }}
+    needs: [matrix, manifest]
+    if: >-
+      ${{ always() && !cancelled()
+          && needs.matrix.outputs.publish == 'true'
+          && github.ref == 'refs/heads/main'
+          && (needs.manifest.result == 'success' || needs.manifest.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,13 +295,16 @@ jobs:
           push: true
           # Immutable per-version, per-arch staging tag -- never the public :<pg>.
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:${{ matrix.pg }}-${{ matrix.version }}-${{ matrix.arch }}
+          # Registry-only cache. The type=gha cache is deliberately NOT used: on
+          # a full rebuild (build_all) hundreds of jobs share the repo's 10 GB
+          # GHA cache, which evicts entries mid-build ("cache entry no longer
+          # exists"). The GHCR buildcache has no such cap and gives the same
+          # cross-run reuse.
           cache-from: |
-            type=gha,scope=${{ matrix.extension }}-${{ matrix.pg }}-${{ matrix.arch }}
             type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-${{ matrix.arch }}
             ${{ matrix.extension == 'plv8' && format('type=registry,ref={0}/{1}/plv8-v8:{2}', env.REGISTRY, github.repository_owner, matrix.version) || '' }}
             ${{ matrix.vcpkg_version != '' && format('type=registry,ref={0}/{1}/pg-lake-vcpkg:{2}', env.REGISTRY, github.repository_owner, matrix.vcpkg_version) || '' }}
           cache-to: |
-            type=gha,mode=max,scope=${{ matrix.extension }}-${{ matrix.pg }}-${{ matrix.arch }}
             type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-${{ matrix.arch }},mode=max
 
   build-apt:
@@ -349,10 +352,8 @@ jobs:
           # Immutable, multi-arch per-version staging tag -- never the public :<pg>.
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:${{ matrix.pg }}-${{ matrix.version }}
           cache-from: |
-            type=gha,scope=${{ matrix.extension }}-${{ matrix.pg }}-all
             type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-all
           cache-to: |
-            type=gha,mode=max,scope=${{ matrix.extension }}-${{ matrix.pg }}-all
             type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-all,mode=max
 
   # ---------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,15 @@ list: ## List available extensions
 # Cache scope for GHA cache (used in CI). Set to enable layer caching.
 CACHE_SCOPE ?=
 
+# Registry to pull published BuildKit cache from (used in CI). When set, a
+# from-source build restores the heavy intermediate stages from the per-arch
+# buildcache-<pg>-<arch> tag the `build` publish job writes, so changed/heavy
+# extensions are not recompiled from scratch on every test run. Read-only: the
+# test jobs never push cache (only the publish `build` job does).
+CACHE_REGISTRY ?=
+# Architecture selecting the per-arch cache tag/scope (default: build host).
+CACHE_ARCH ?= amd64
+
 build: _check-ext ## Build a single extension image
 	$(eval EXT_APT_PACKAGE := $(shell bash -c 'source extensions/$(EXT)/extension.conf && echo "$$APT_PACKAGE"'))
 	$(eval EXT_VERSION := $(shell ./scripts/ext-version.sh $(EXT) $(PG)))
@@ -83,9 +92,10 @@ build: _check-ext ## Build a single extension image
 	@echo "Building $(PREFIX)-$(EXT):$(PG) (extension $(EXT_VERSION), $(if $(filter Dockerfile.apt,$(DOCKERFILE)),shared apt template,custom Dockerfile))..."
 	docker buildx build \
 		$(if $(PLATFORM),--platform $(PLATFORM)) \
-		$(if $(CACHE_SCOPE),--cache-from type=gha$(comma)scope=$(EXT)-$(PG)) \
-		$(if $(CACHE_SCOPE),--cache-from type=registry$(comma)ref=$(REGISTRY)/$(PREFIX)-$(EXT):$(PG)) \
-		$(if $(CACHE_SCOPE),--cache-to type=gha$(comma)mode=max$(comma)scope=$(EXT)-$(PG)) \
+		$(if $(CACHE_SCOPE),--cache-from type=gha$(comma)scope=$(EXT)-$(PG)-$(CACHE_ARCH)) \
+		$(if $(CACHE_REGISTRY),--cache-from type=registry$(comma)ref=$(CACHE_REGISTRY)/$(PREFIX)-$(EXT):buildcache-$(PG)-$(CACHE_ARCH)) \
+		$(if $(CACHE_REGISTRY),--cache-from type=registry$(comma)ref=$(CACHE_REGISTRY)/$(PREFIX)-$(EXT):$(PG)) \
+		$(if $(CACHE_SCOPE),--cache-to type=gha$(comma)mode=max$(comma)scope=$(EXT)-$(PG)-$(CACHE_ARCH)) \
 		--build-arg PG_MAJOR=$(PG) \
 		--build-arg PG_TAG=$(or $(PG_TAG),$(PG)) \
 		--build-arg EXT_VERSION=$(EXT_VERSION) \

--- a/scripts/ci-free-disk.sh
+++ b/scripts/ci-free-disk.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Reclaim disk on GitHub-hosted runners before disk-heavy extension builds.
+#
+# The PG 18+ test jobs may rebuild many source-built extensions from scratch in
+# a single job (e.g. pg_lake / pg_duckdb, which compile DuckDB). The stock
+# ubuntu-latest runner ships with only ~14 GB free on `/`, which is not enough
+# for that many concurrent from-source builds -- the failure mode is
+# `No space left on device` mid-compile. Removing the preinstalled language
+# toolchains and SDKs that our builds never use frees ~25-30 GB.
+#
+# This only deletes runner-preinstalled content that the CI jobs do not use; it
+# does not touch Docker, buildx, the checkout, or the actions runtime.
+#
+# Usage: ci-free-disk.sh
+set -eu
+
+avail() { df -P / | awk 'NR==2 { printf "%.1f", $4 / 1024 / 1024 }'; }
+
+echo "Disk before cleanup: $(avail) GiB free"
+
+# Large preinstalled toolchains/SDKs unused by extension builds. `sudo rm` each
+# independently so a missing path on a future runner image is not fatal.
+for path in \
+  /usr/local/lib/android \
+  /usr/share/dotnet \
+  /opt/ghc \
+  /usr/local/.ghcup \
+  /opt/hostedtoolcache/CodeQL \
+  /usr/local/share/powershell \
+  /usr/share/swift \
+  /usr/local/share/chromium \
+  /usr/local/lib/node_modules \
+  /usr/share/miniconda \
+  /opt/az \
+; do
+  sudo rm -rf "$path" 2>/dev/null || true
+done
+
+# Drop preinstalled Docker images we never use (the postgres base images we need
+# are pulled fresh). Keep the builder cache intact -- callers manage that.
+docker image prune -af >/dev/null 2>&1 || true
+
+echo "Disk after cleanup:  $(avail) GiB free"
+df -h /

--- a/scripts/ci-prepare-images.sh
+++ b/scripts/ci-prepare-images.sh
@@ -4,24 +4,36 @@
 # that combined-image and profile composition (make image / make test /
 # make test-image, all with REGISTRY=local) never consume a stale layer.
 #
-# Policy per extension:
-#   * in $CHANGED            -> build from source (fresh layer with the change)
-#   * otherwise              -> pull the published image and retag as local/
-#   * pull missing/unusable  -> build from source (fallback)
-#   * CI_SKIP=1 + unpublished -> skip (long builds not exercised in CI)
+# BUILD-ONCE MODEL
+# ----------------
+# Layers are compiled exactly once, by the CI `build` job, which pushes an
+# immutable per-commit staging tag to the registry:
+#   * source extension (native, per-arch):  pgx-<ext>:<pg>-<version>-<arch>
+#   * apt extension    (multi-arch):         pgx-<ext>:<pg>-<version>
+# The test/profile/integration jobs then *pull* those images instead of
+# recompiling them. On merge, the `promote` job retags them into the public
+# multi-arch :<pg> / :<pg>-<version> manifests -- again without rebuilding.
 #
-# This is the single source of truth the CI test jobs use to assemble images;
-# because changed layers are always rebuilt and unchanged ones come from the
-# last published (correct) release, there is no window where a composition
-# step binds an out-of-date layer -- the class of bug behind "the azure
-# profile pulled a pre-fix postgis".
+# Policy per extension:
+#   * CI_SKIP=1              -> never built in CI; use a published image or skip
+#   * changed (this run)     -> pull the freshly-built <version>[-<arch>] staging
+#                               tag the `build` job just pushed; if it is absent
+#                               (fork PR with no registry write, or a rerun on a
+#                               dirty runner) fall back to building from source
+#   * unchanged              -> pull the published multi-arch :<pg> and retag
+#   * pull missing/unusable  -> build from source (fallback)
+#
+# Because changed layers come from this run's `build` (or a local rebuild) and
+# unchanged ones come from the last published release, there is no window where
+# a composition step binds an out-of-date layer.
 #
 # Usage:  ci-prepare-images.sh <pg> <ext...>
 # Env:
-#   SOURCE_REGISTRY  registry to pull unchanged images from (default ghcr.io/pglayers)
+#   SOURCE_REGISTRY  registry to pull images from (default ghcr.io/pglayers)
 #   PREFIX           image name prefix (default pgx)
 #   PG_TAG           base postgres tag for source builds (default = <pg>)
-#   CHANGED          space-separated list of extensions to build from source
+#   CHANGED          space-separated list of extensions changed in this run
+#   CACHE_ARCH       arch selecting the per-arch staging/cache tag (default host)
 set -euo pipefail
 
 PG="${1:?usage: ci-prepare-images.sh <pg> <ext...>}"
@@ -32,23 +44,43 @@ PREFIX="${PREFIX:-pgx}"
 PG_TAG="${PG_TAG:-$PG}"
 CHANGED=" ${CHANGED:-} "
 
+# Runner architecture, selecting the per-arch staging tag (<pg>-<ver>-<arch>)
+# and the per-arch registry build cache (buildcache-<pg>-<arch>).
+CACHE_ARCH="${CACHE_ARCH:-$(dpkg --print-architecture 2>/dev/null || echo amd64)}"
+
+# Below this free-space threshold (GiB) we prune the BuildKit cache between any
+# from-source fallback builds. Each finished layer is already `--load`ed into
+# the docker image store, so its build cache is safe to drop.
+DISK_FLOOR_GIB="${DISK_FLOOR_GIB:-14}"
+
 is_changed() { case "$CHANGED" in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+avail_gib() { df -P / | awk 'NR==2 { printf "%d", $4 / 1024 / 1024 }'; }
+
+prune_if_low() {
+	local avail
+	avail="$(avail_gib)"
+	if [ "${avail:-99}" -lt "$DISK_FLOOR_GIB" ]; then
+		echo "::group::prune build cache (only ${avail} GiB free, floor ${DISK_FLOOR_GIB})"
+		docker builder prune -af >/dev/null 2>&1 || true
+		docker image prune -f >/dev/null 2>&1 || true
+		echo "  now $(avail_gib) GiB free"
+		echo "::endgroup::"
+	fi
+}
 
 build_local() {
 	local ext="$1"
-	echo "::group::build $ext (PG $PG)"
-	make build EXT="$ext" PG="$PG" PG_TAG="$PG_TAG" REGISTRY=local CACHE_SCOPE=ci
+	echo "::group::build $ext (PG $PG) from source"
+	make build EXT="$ext" PG="$PG" PG_TAG="$PG_TAG" REGISTRY=local \
+		CACHE_SCOPE=ci CACHE_REGISTRY="$SOURCE_REGISTRY" CACHE_ARCH="$CACHE_ARCH"
 	echo "::endgroup::"
+	prune_if_low
 }
 
 # For PG >= 18 a pulled image MUST use the isolated layout (files under /lib or
 # /share/extension), not a stale classic image. Isolated images are FROM scratch
-# (no shell), so inspect the layout via docker export. This is a layout guard
-# only; it does not verify $ORIGIN RUNPATH / mangled sonames. That is sound here
-# because any layer that bundles runtime libs (the only ones needing the RUNPATH
-# fix) is rebuilt from source whenever its Dockerfile changes -- i.e. it lands in
-# $CHANGED and is built, not pulled -- so a pulled image is either non-bundling
-# (RUNPATH irrelevant) or already-published-with-the-fix.
+# (no shell), so inspect the layout via docker export.
 isolated_ok() {
 	local img="$1"
 	[ "$PG" -ge 18 ] 2>/dev/null || return 0
@@ -62,6 +94,18 @@ isolated_ok() {
 	[ "$ok" = yes ]
 }
 
+# Pull $1 and, if it is a usable (isolated-ok) image, retag it as $local_img.
+# Returns 0 on success, 1 otherwise (leaving no dangling pulled image).
+try_pull() {
+	local src="$1"
+	if docker pull "$src" 2>/dev/null && isolated_ok "$src"; then
+		docker tag "$src" "$local_img"
+		return 0
+	fi
+	docker rmi "$src" 2>/dev/null || true
+	return 1
+}
+
 for ext in "$@"; do
 	[ -d "extensions/$ext" ] || continue
 	# Distinguish "not available for this PG" (empty output, skip) from a real
@@ -73,30 +117,48 @@ for ext in "$@"; do
 	[ -z "$ver" ] && { echo "skip $ext (no version for PG $PG)"; continue; }
 
 	local_img="local/${PREFIX}-${ext}:${PG}"
-	ci_skip="$(bash -c "source extensions/$ext/extension.conf && echo \"\${CI_SKIP:-}\"")"
-	src="${SOURCE_REGISTRY}/${PREFIX}-${ext}:${PG}"
+	# Already prepared earlier in this job.
+	docker image inspect "$local_img" >/dev/null 2>&1 && continue
 
-	# Changed extensions are ALWAYS rebuilt from source -- never reuse a
-	# possibly-stale local image (e.g. from a rerun on a non-clean runner) --
-	# so the freshly changed code is what gets tested. `make build` is
-	# BuildKit-cached, so a redundant rebuild is cheap. (CI_SKIP extensions are
-	# never built in CI, so they fall through to the pull path regardless.)
-	if [ "$ci_skip" != "1" ] && is_changed "$ext"; then
-		build_local "$ext"
+	ci_skip=""
+	apt_package=""
+	# shellcheck disable=SC1090
+	{ ci_skip="$(source "extensions/$ext/extension.conf" && echo "${CI_SKIP:-}")"; }
+	# shellcheck disable=SC1090
+	{ apt_package="$(source "extensions/$ext/extension.conf" && echo "${APT_PACKAGE:-}")"; }
+
+	published="${SOURCE_REGISTRY}/${PREFIX}-${ext}:${PG}"
+
+	# CI_SKIP: never compiled in CI (too heavy). Use a published image if usable.
+	if [ "$ci_skip" = "1" ]; then
+		try_pull "$published" \
+			|| echo "skip $ext (CI_SKIP=1 and no usable published image)"
 		continue
 	fi
 
-	# Unchanged (or CI_SKIP): a local image from an earlier step is fine.
-	docker image inspect "$local_img" >/dev/null 2>&1 && continue
-
-	if docker pull "$src" 2>/dev/null && isolated_ok "$src"; then
-		docker tag "$src" "$local_img"
-	elif [ "$ci_skip" = "1" ]; then
-		echo "skip $ext (CI_SKIP=1 and no usable published image)"
-		docker rmi "$src" 2>/dev/null || true
-	else
-		echo "no usable published image for $ext; building from source"
-		docker rmi "$src" 2>/dev/null || true
-		build_local "$ext"
+	if is_changed "$ext"; then
+		# Freshly built by the `build` job in THIS run (same-repo / schedule /
+		# dispatch). APT layers are multi-arch (<pg>-<ver>); source layers are
+		# per-arch (<pg>-<ver>-<arch>).
+		if [ -n "$apt_package" ]; then
+			staged="${SOURCE_REGISTRY}/${PREFIX}-${ext}:${PG}-${ver}"
+		else
+			staged="${SOURCE_REGISTRY}/${PREFIX}-${ext}:${PG}-${ver}-${CACHE_ARCH}"
+		fi
+		if try_pull "$staged"; then
+			echo "pulled freshly-built $ext ($PG-$ver)"
+		else
+			# Fork PR (no registry write) or unavailable -> compile locally so
+			# the changed code is still validated.
+			echo "no freshly-built image for changed $ext; building from source"
+			build_local "$ext"
+		fi
+		continue
 	fi
+
+	# Unchanged: the last published multi-arch release layer.
+	try_pull "$published" || {
+		echo "no usable published image for $ext; building from source"
+		build_local "$ext"
+	}
 done


### PR DESCRIPTION
## Problem

The split PR/push pipeline recompiled every changed layer **up to three times** — PR `test` build, push `test` build, push publish `build` — and shared nothing across jobs or runs (GitHub Actions cache is branch-scoped, so a `main` run can't read a PR's cache, and the `test` jobs never populated a registry buildcache).

On **PG 18** this compounded into a self-perpetuating deadlock:

1. ~29 extensions' published `:18` images predate the isolated-layout migration (#34) and are (correctly) rejected by `ci-prepare-images.sh`'s `isolated_ok` guard, so every run **rebuilt them from source**.
2. ~29 concurrent from-scratch builds (incl. `pg_lake`/DuckDB) exhausted the runner disk → `No space left on device`.
3. That failed the `test` gate → publish skipped → stale `:18` images never replaced → **repeat forever**.

(This is what turned a routine documentdb bump merge red.)

## Fix — compile each layer exactly once

- **`build-native` / `build-apt`** run on the **PR** (same-repo), schedule and dispatch — **not** on push. They push immutable per-version **staging** tags (`source: :<pg>-<version>-<arch>`, `apt: :<pg>-<version>`) + a per-arch registry buildcache. Split into two jobs so a full rebuild stays under GitHub's **256-job matrix cap** (the single matrix was 294 — a latent bug in the weekly `build_all`).
- **`test` / `test-profile` / `integration`** now **pull** those staging images (and the published `:<pg>` for unchanged layers) instead of rebuilding. No more mass recompile → no disk exhaustion.
- **Fork PRs** (which can't push to GHCR) transparently fall back to building the changed layer from source in the test job (existing pull-else-build path). They validate but never publish.
- On **merge to main**, the new **`promote`** stage (`manifest` + `profile-images`) retags the already-built, already-tested per-arch staging images into the public multi-arch `:<pg>` / `:<pg>-<version>` manifests and composes the profiles — **no rebuild**. Gated on the PR's green run via branch protection.

### Self-healing
Merging this infra change sets `build_all=true`, so the PR rebuilds every extension in the **isolated** layout and the merge promotes them — replacing the stale-classic `:18` images that caused the deadlock. Afterwards, unchanged layers are pulled (fast, low disk) on every run.

## Answering "why was it recomputed twice, and can post-commit reuse pre-commit builds?"
Yes, it was (2–3×). The only cross-run/cross-branch reuse channel is the **registry** (GHA cache is branch-scoped). This PR makes the registry the single artifact store: build-once on the PR → pull everywhere → promote on merge.

## Supporting changes
- `ci-prepare-images.sh`: pull the freshly-built staging tag for changed exts (fork/unavailable → build from source); prune BuildKit cache between fallback builds when disk is low.
- `Makefile`: read the published per-arch registry buildcache; align the gha cache scope to `<ext>-<pg>-<arch>` so fallback/local builds reuse published layers.
- `scripts/ci-free-disk.sh`: reclaim ~25–30 GB of unused runner toolchains before heavy source builds.

## Validation
- `actionlint` clean; YAML parses; `shellcheck` clean on both scripts.
- The real end-to-end proof is this PR's own CI: `build_all` rebuilds every extension isolated, `test`/`test-profile`/`integration` pull + validate, and (on merge) `promote` publishes without rebuilding.

> [!NOTE]
> Trade-offs: staging tags are per-version immutable, so same-version Dockerfile-only changes overwrite that version's staging tag (consumers use the `:<pg>` manifest, only updated on merge). APT versions are resolved at plan time, so PGDG bumping between a PR and its merge is a (rare, self-healing via the weekly rebuild) edge case. Direct pushes to `main` (bypassing a PR) have no staging images to promote — relies on branch protection.