### PR TITLE
fix(pg_lake): restrict to PG17 (pg_extension_base breaks PG18 extension_control_path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ promoted to stable.
 | [pg_hint_plan](https://github.com/ossc-db/pg_hint_plan) | 1.7.1 | 17, 18 | Tweak execution plans using hints in SQL comments |
 | [pg_ivm](https://github.com/sraoss/pg_ivm) | 1.13 | 17, 18 | Incremental View Maintenance for materialized views |
 | [pg_jsonschema](https://github.com/supabase/pg_jsonschema) | 0.3.4 | 17, 18 | JSON Schema validation |
-| [pg_lake](https://github.com/Snowflake-Labs/pg_lake) | 3.4.1 | 17, 18 | Iceberg and data lake access (Parquet, CSV, JSON via DuckDB) |
+| [pg_lake](https://github.com/Snowflake-Labs/pg_lake) | 3.4.1 | 17 | Iceberg and data lake access (Parquet, CSV, JSON via DuckDB) |
 | [pg_net](https://github.com/supabase/pg_net) | 0.20.3 | 17, 18, 19 | Async non-blocking HTTP/HTTPS requests |
 | [pg_partman](https://github.com/pgpartman/pg_partman) | 5.4.3 | 17, 18, 19 | Automated table partition management |
 | [pg_permissions](https://github.com/cybertec-postgresql/pg_permissions) | 1.4.1 | 17, 18, 19 | Review and audit object permissions against a desired state |
@@ -369,6 +369,20 @@ CREATE EXTENSION pg_lake CASCADE;
 
 **Note:** pg_lake conflicts with pg_duckdb (both bundle `libduckdb.so`).
 Do not use both in the same image.
+
+**PostgreSQL 17 only.** pg_lake requires its `pg_extension_base` shim in
+`shared_preload_libraries`. That shim installs a `ProcessUtility` hook
+that intercepts every `CREATE EXTENSION` and looks up the target's
+control file in the hardcoded `$system` sharedir, ignoring PostgreSQL
+18's `extension_control_path`. Because the PG 18+ isolated layout
+installs every extension under `/extensions/<ext>/share` and resolves
+them purely via `extension_control_path`, preloading `pg_extension_base`
+would break `CREATE EXTENSION` for **every** extension in the image (and
+pg_lake itself). pg_lake is therefore built only for the PG 17 classic
+layout until upstream teaches `pg_extension_base` to honor
+`extension_control_path`. See
+[issue #37](https://github.com/pglayers/pglayers/issues/37) and upstream
+[Snowflake-Labs/pg_lake#494](https://github.com/Snowflake-Labs/pg_lake/issues/494).
 
 ### Profile images (auto-configuration)
 

--- a/extensions/pg_lake/extension.conf
+++ b/extensions/pg_lake/extension.conf
@@ -1,10 +1,20 @@
 DESCRIPTION="Iceberg and data lake access for PostgreSQL (Parquet, CSV, JSON via DuckDB)"
 REPO="https://github.com/Snowflake-Labs/pg_lake.git"
 LICENSE="Apache-2.0"
+# PG17 only. pg_lake's mandatory shared_preload_libraries shim
+# `pg_extension_base` installs a ProcessUtility hook that intercepts EVERY
+# CREATE EXTENSION and resolves the target's control file from a hardcoded
+# `$system` sharedir (pg_extension_base/src/extension_control_file.c), ignoring
+# PostgreSQL 18's `extension_control_path`. The PG18+ isolated layout installs
+# every extension under /extensions/<ext>/share and relies entirely on
+# `extension_control_path`, so preloading pg_extension_base breaks CREATE
+# EXTENSION for ALL extensions in the image (and pg_lake itself). Until upstream
+# teaches pg_extension_base to honor extension_control_path, pg_lake is
+# restricted to the PG17 classic layout. See issue #37 and upstream
+# Snowflake-Labs/pg_lake#494.
 VERSION_17="v3.4.1"
-VERSION_18="v3.4.1"
 VCPKG_VERSION="2025.10.17"
 SHARED_PRELOAD="pg_extension_base"
 COMPANION_CMD="pgduck_server --cache_dir /tmp/pg_lake_cache"
 CONFLICTS="pg_duckdb"
-NOTES="Includes pgduck_server binary. Conflicts with pg_duckdb (both bundle DuckDB)."
+NOTES="PG17 only (pg_extension_base ignores PG18 extension_control_path; see #37). Includes pgduck_server binary. Conflicts with pg_duckdb (both bundle DuckDB)."


### PR DESCRIPTION
## Problem

`CREATE EXTENSION <any>` fails on `ghcr.io/pglayers/pglayers-full:18` (and any PG18+ profile that includes pg_lake) with:

```
ERROR:  extension "vector" is not available
DETAIL:  Could not open extension control file
         "/usr/share/postgresql/18/extension/vector.control": No such file or directory.
```

even though `SHOW extension_control_path;` is correct and the control file exists at `/extensions/<ext>/share/extension/<ext>.control`.

Fixes #37.

## Root cause

pg_lake's mandatory `shared_preload_libraries` shim `pg_extension_base` installs a global `ProcessUtility` hook (`extension_dependencies.c`) that intercepts **every** `CREATE EXTENSION` and resolves the target's control file via `GetExtensionControlFilename` (`extension_control_file.c`), which hardcodes the `$system` sharedir and **ignores PostgreSQL 18's `extension_control_path`**.

The PG18+ isolated layout installs every extension under `/extensions/<ext>/share` and relies entirely on `extension_control_path`, so preloading `pg_extension_base` breaks `CREATE EXTENSION` for **all** extensions in the combined image — and for pg_lake itself. PG17 (classic layout, everything in `$system`) is unaffected, which matches the reporter's observation that `:17` works.

Verified by bisecting `shared_preload_libraries`: removing only `pg_extension_base` makes `CREATE EXTENSION vector;` succeed in the full image; the identical file layout works on a vanilla `postgres:18`.

Reported upstream: Snowflake-Labs/pg_lake#494.

## Fix

Per the repo policy (*"an extension that builds on one PG version but fails on another … remove the unsupported version"*), restrict pg_lake to **PG17**:

- Remove `VERSION_18` from `extensions/pg_lake/extension.conf` (+ document why).
- Update the README version column (`17, 18` → `17`) and add a config note.

pg_lake is non-functional on PG18 regardless (with the shim preloaded nothing can be created; without it pg_lake refuses to load), so this loses nothing that currently works while un-breaking the whole PG18 image.

## Effect on published images

- `ext-version.sh pg_lake 18/19` now returns empty, so `make image` / `test-layers.sh` exclude pg_lake on PG18/19 and drop `pg_extension_base` from the generated `shared_preload_libraries`.
- On merge, the `profile-images` job recomposes and republishes `pglayers-full:18` and `pglayers-azure:18` (and 19) **without** pg_lake. Per-extension `pgx-*:18` layers are unchanged (they were never broken).

## Validation

- `make check-profiles` ✅
- `make check-licenses` ✅ (79 ok, 0 rejected)
- Manual: full preload minus `pg_extension_base` → `CREATE EXTENSION vector;` succeeds.
