### PR TITLE
ci(monitor): use GitHub App token instead of expiring PAT

### DIFF
--- a/.github/workflows/monitor-apt-versions.yml
+++ b/.github/workflows/monitor-apt-versions.yml
@@ -20,10 +20,21 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Mint a short-lived GitHub App installation token. Unlike GITHUB_TOKEN,
+      # an App token is a distinct identity, so the PR it opens (and the merge
+      # push) DO trigger ci.yml -- required for the build-once pipeline to build,
+      # test, and promote the version bump. Unlike a PAT it is generated fresh
+      # each run and expires in ~1h, so there is nothing to rotate.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7
         with:
-          # PAT so the PR triggers downstream workflows; GITHUB_TOKEN fallback.
-          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Regenerate apt-versions lockfile
         run: |
@@ -34,7 +45,7 @@ jobs:
 
       - name: Open PR on change
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -eo pipefail
 

--- a/.github/workflows/monitor-extensions.yml
+++ b/.github/workflows/monitor-extensions.yml
@@ -13,15 +13,25 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Mint a short-lived GitHub App installation token. Unlike GITHUB_TOKEN,
+      # an App token is a distinct identity, so the PR it opens (and the merge
+      # push) DO trigger ci.yml -- required for the build-once pipeline to build,
+      # test, and promote the version bump. Unlike a PAT it is generated fresh
+      # each run and expires in ~1h, so there is nothing to rotate.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7
         with:
-          # Use PAT so that pushes and PRs trigger downstream workflows.
-          # Falls back to GITHUB_TOKEN if PAT_TOKEN is not set.
-          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Check for extension updates
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -eo pipefail
 


### PR DESCRIPTION
## Summary
Replace the expired `PAT_TOKEN` in `monitor-apt-versions.yml` and `monitor-extensions.yml` with a short-lived GitHub App installation token (`actions/create-github-app-token@v2`).

**Why:** the monitors need a non-`GITHUB_TOKEN` identity so the PRs they open (and the merge push) trigger `ci.yml`'s build-once pipeline. The `PAT_TOKEN` expired ~30 days after creation, silently breaking both monitors since 2026-07-24. An App token behaves like a PAT for triggering downstream workflows but is minted fresh each run (~1h TTL), so there is nothing to rotate.

## Required before merge (else the monitors fail at the app-token step)
Add two repo secrets and remove the old one:
- `APP_ID`, `APP_PRIVATE_KEY` (from a GitHub App with Contents:RW + Pull requests:RW, installed on this repo)
- delete `PAT_TOKEN`

## Validation
- `actionlint` clean on both monitor workflows.

_Note: the startup-warnings commits originally on this branch were already merged via #44, so this PR was rebased onto `main` down to just the CI change._