### PR TITLE
ci(monitor): use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/monitor-apt-versions.yml
+++ b/.github/workflows/monitor-apt-versions.yml
@@ -29,7 +29,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7

--- a/.github/workflows/monitor-extensions.yml
+++ b/.github/workflows/monitor-extensions.yml
@@ -22,7 +22,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
`actions/create-github-app-token@v3` deprecates the `app-id` input in favor of `client-id` (verified against the action's `action.yml` at the `v3` tag). Both monitor workflows emitted a deprecation warning on their last runs. This switches them to `client-id`.

## Required before merge
Add the `APP_CLIENT_ID` secret (the GitHub App's **Client ID**, found on the App's settings page just below the App ID):
```
gh secret set APP_CLIENT_ID --repo pglayers/pglayers --body "<Iv... client id>"
```
After merge, `APP_ID` is unused and can be deleted.

## Notes
- `actionlint` flags `client-id` as unknown — this is a **false positive** from its stale bundled action metadata; the real `v3` `action.yml` defines `client-id` and marks `app-id` deprecated.