### PR TITLE
feat(pgmq): add pgmq message queue extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,19 @@ This means:
    `make add-apt-ext` generates a starter `test.sql` stub with the load
    assertion; replace the placeholder with real checks.
 
+5. **Profile membership (required)** -- Every extension **must** be added
+   to `profiles/full.txt` (unless it carries `CI_SKIP=1` in
+   `extension.conf`). CI runs `make check-profiles`, which fails if
+   `profiles/full.txt` is out of sync with the `extensions/` directory --
+   forgetting this breaks the build. Insert the extension's **directory
+   name** in the file's existing sort order (locale-aware `sort`, which
+   ignores underscores -- e.g. `pgmq` goes between `pglogical` and
+   `pg_net`) and run `make check-profiles` to confirm. If the extension is
+   also available in a managed PostgreSQL service, add it to the matching
+   service profile too (e.g. `profiles/azure.txt`); those profiles are
+   curated (not required to list every extension) and must never contain
+   `CONFLICTS` pairs.
+
 The collision, overwrite, and ldd checks are automatic for all
 extensions in the `extensions/` directory -- no manual update needed
 for those. (Collision and overwrite checks are skipped for PG 18+ since
@@ -304,9 +317,12 @@ adding a new source-built extension:
 4. **GitLab-hosted repos** -- Automatically detected from the `REPO`
    URL. The workflow uses the GitLab Releases API instead of GitHub.
 
-5. **Profile membership** -- If the extension is available in a managed
-   PostgreSQL service (e.g., Azure), add it to the appropriate profile
-   in `profiles/`. Run `make check-profiles` to validate.
+5. **Profile membership** -- Every source-built extension must be in
+   `profiles/full.txt` like any other (see the "Adding a new extension
+   checklist" above; `make check-profiles` enforces it). Additionally, if
+   the extension is available in a managed PostgreSQL service (e.g.,
+   Azure), add it to the appropriate service profile in `profiles/`. Run
+   `make check-profiles` to validate.
 
 ### Dockerfile requirements
 
@@ -512,23 +528,30 @@ must be updated in the same commit**:
    extension name (linked to its repo), PG versions, and description.
    Also update the `shared_preload_libraries` table if applicable.
 
-2. **`README.md` "Configuration notes" section** -- If the extension
+2. **`profiles/full.txt` membership (required, CI-enforced)** -- Add the
+   extension's directory name in the file's existing sort order (unless it
+   carries `CI_SKIP=1`). `make check-profiles` runs in CI and fails the
+   build if `profiles/full.txt` is out of sync with `extensions/` --
+   this is the step most easily forgotten. Also add it to any service
+   profile (e.g. `profiles/azure.txt`) where the extension is available.
+
+3. **`README.md` "Configuration notes" section** -- If the extension
    requires any special configuration beyond `shared_preload_libraries`
    (e.g., environment variables, GUC parameters, init scripts, or
    runtime setup), document it in the README under "Configuration
    notes" with a dedicated subsection.
 
-3. **`make list` output** -- This is automatic (driven by
+4. **`make list` output** -- This is automatic (driven by
    `extension.conf` files), but verify the description is concise and
    the PG version columns are correct.
 
-4. **`tests/test-layers.sh`** -- As described above (name mapping,
+5. **`tests/test-layers.sh`** -- As described above (name mapping,
    `SKIP_CREATE_EXT` if needed) plus a required `extensions/<ext>/test.sql`.
 
-5. **`extension.conf` LICENSE field** -- Every extension must document
+6. **`extension.conf` LICENSE field** -- Every extension must document
    its license. Run `make list` and verify the new extension appears.
 
-6. **`extension.conf` DEPENDS field** -- If the extension requires
+7. **`extension.conf` DEPENDS field** -- If the extension requires
    another extension at runtime, add a `DEPENDS` field with a
    comma-separated list of SQL extension names (not directory names):
    ```bash
@@ -540,7 +563,7 @@ must be updated in the same commit**:
    running `CREATE EXTENSION`. Both pglayers extensions and built-in
    contrib extensions are valid values.
 
-7. **`extension.conf` PG_CONF field** -- If the extension requires
+8. **`extension.conf` PG_CONF field** -- If the extension requires
    GUC settings in `postgresql.conf` beyond `shared_preload_libraries`,
    add a `PG_CONF` field with pipe-delimited config lines:
    ```bash
@@ -565,7 +588,7 @@ must be updated in the same commit**:
    > `combined-config.sh` (or, for per-extension GUCs, to `PG_CONF`) so
    > both consumers stay in lockstep.
 
-8. **`extension.conf` COMPANION_CMD field** -- If the extension
+9. **`extension.conf` COMPANION_CMD field** -- If the extension
    requires a standalone background process running alongside
    PostgreSQL, add a `COMPANION_CMD` field:
    ```bash
@@ -581,7 +604,7 @@ must be updated in the same commit**:
    because it embeds a multi-threaded engine incompatible with
    PostgreSQL's process model).
 
-9. **`extension.conf` CONFLICTS field** -- Some extensions cannot be
+10. **`extension.conf` CONFLICTS field** -- Some extensions cannot be
    loaded into the same backend *no matter how well the layers are
    isolated*, because the conflict is at the **runtime/symbol** level, not
    the file level, and file/soname isolation can't fix it. PostgreSQL loads

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ promoted to stable.
 | [pgfincore](https://github.com/klando/pgfincore) | 1.4.0 | 17, 18, 19 | Inspect and manage OS page cache for data files |
 | [pgjwt](https://github.com/michelp/pgjwt) | master | 17, 18, 19 | JSON Web Token (JWT) generation and validation |
 | [pglogical](https://github.com/2ndQuadrant/pglogical) | 2.4.7 | 17, 18, 19 | Logical streaming replication using publish/subscribe model |
+| [pgmq](https://github.com/pgmq/pgmq) | 1.12.0 | 17, 18, 19 | Lightweight message queue on Postgres (like AWS SQS/RSMQ) |
 | [pgnodemx](https://github.com/CrunchyData/pgnodemx) | 2.0.1 | 17, 18 | Expose node OS/cgroup metrics as SQL (container-aware monitoring) |
 | [pgpcre](https://github.com/petere/pgpcre) | 0.20190509 | 17, 18, 19 | Perl-compatible regular expression (PCRE) type and functions |
 | [pgrouting](https://github.com/pgRouting/pgrouting) | 4.0.1 | 17, 18, 19 | Geospatial routing and network analysis on PostGIS |

--- a/extensions/pgmq/Dockerfile
+++ b/extensions/pgmq/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+ARG PG_MAJOR=17
+ARG PG_TAG=${PG_MAJOR}
+ARG LAYOUT=classic
+
+FROM postgres:${PG_TAG} AS builder
+ARG PG_MAJOR
+ARG EXT_VERSION=v1.12.0
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+    build-essential git ca-certificates \
+    postgresql-server-dev-${PG_MAJOR}
+
+RUN git clone --branch ${EXT_VERSION} --depth 1 \
+    https://github.com/pgmq/pgmq.git /tmp/ext
+
+# The extension sources live in the pgmq-extension/ subdirectory.
+WORKDIR /tmp/ext/pgmq-extension
+
+# pgmq is pure SQL/plpgsql -- no compilation. `make` generates the versioned
+# sql/pgmq--<ver>.sql from sql/pgmq.sql (DATA is resolved via wildcard), then
+# `make install` copies the SQL + control files into place.
+RUN make && make install DESTDIR=/output
+
+# --- Layout selection ---
+# Classic: files at standard PG paths (PG 17)
+FROM scratch AS classic
+COPY --from=builder /output/ /
+
+# Isolated: flat /lib/ + /share/extension/ layout (PG 18+, CNPG-compatible)
+FROM builder AS normalizer
+ARG PG_MAJOR
+RUN mkdir -p /isolated/lib /isolated/share/extension && \
+    (find /output/usr/lib/postgresql/${PG_MAJOR}/lib -maxdepth 1 -type f \
+        -exec cp -a {} /isolated/lib/ \; 2>/dev/null || true) && \
+    cp -a /output/usr/share/postgresql/${PG_MAJOR}/extension/* \
+        /isolated/share/extension/ && \
+    cp -a /output/usr/lib/postgresql/${PG_MAJOR}/lib/bitcode /isolated/lib/bitcode \
+        2>/dev/null || true
+
+FROM scratch AS isolated
+COPY --from=normalizer /isolated/ /
+
+FROM ${LAYOUT}

--- a/extensions/pgmq/extension.conf
+++ b/extensions/pgmq/extension.conf
@@ -1,0 +1,8 @@
+DESCRIPTION="Lightweight message queue on Postgres (like AWS SQS/RSMQ)"
+REPO="https://github.com/pgmq/pgmq.git"
+LICENSE="PostgreSQL"
+VERSION_17="v1.12.0"
+VERSION_18="v1.12.0"
+VERSION_19="v1.12.0"
+SHARED_PRELOAD=""
+NOTES="Pure SQL/plpgsql extension (no shared library). Partitioned queues optionally require pg_partman; core queue functionality does not."

--- a/extensions/pgmq/test.sql
+++ b/extensions/pgmq/test.sql
@@ -1,0 +1,39 @@
+-- pgmq integration tests
+CREATE EXTENSION IF NOT EXISTS pgmq;
+
+-- Test: extension loads and creates the pgmq schema (smoke test)
+SELECT CASE
+    WHEN EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'pgmq')
+    THEN 'PASS pgmq: extension loads and pgmq schema exists'
+    ELSE 'FAIL pgmq: extension loads and pgmq schema exists'
+END;
+
+-- Test: create a queue and send a message, msg_id is returned
+SELECT pgmq.create('test_queue');
+SELECT CASE
+    WHEN (SELECT pgmq.send('test_queue', '{"hello": "world"}')) >= 1
+    THEN 'PASS pgmq: create queue and send returns a msg_id'
+    ELSE 'FAIL pgmq: create queue and send returns a msg_id'
+END;
+
+-- Test: read the message back within a visibility timeout
+SELECT CASE
+    WHEN (SELECT message FROM pgmq.read('test_queue', 30, 1) LIMIT 1)
+         = '{"hello": "world"}'::jsonb
+    THEN 'PASS pgmq: read returns the enqueued message'
+    ELSE 'FAIL pgmq: read returns the enqueued message'
+END;
+
+-- Test: archive moves the message out of the queue into the archive table.
+-- Archive in its own statement so the verification below sees the committed
+-- effect (mutating and reading in one statement would use a stale snapshot).
+SELECT pgmq.archive('test_queue', msg_id) FROM pgmq.q_test_queue;
+SELECT CASE
+    WHEN (SELECT count(*) FROM pgmq.a_test_queue) = 1
+     AND (SELECT count(*) FROM pgmq.q_test_queue) = 0
+    THEN 'PASS pgmq: archive moves message to archive table'
+    ELSE 'FAIL pgmq: archive moves message to archive table'
+END;
+
+-- Cleanup
+SELECT pgmq.drop_queue('test_queue');

--- a/profiles/full.txt
+++ b/profiles/full.txt
@@ -34,6 +34,7 @@ pg_jsonschema
 pgjwt
 pg_lake
 pglogical
+pgmq
 pg_net
 pgnodemx
 pg_partman

--- a/tests/test-layers.sh
+++ b/tests/test-layers.sh
@@ -491,6 +491,7 @@ declare -A EXT_SQL_NAMES=(
     [pgaudit]="pgaudit"
     [pgjwt]="pgjwt"
     [pglogical]="pglogical"
+    [pgmq]="pgmq"
     [pgrouting]="pgrouting"
     [pgsodium]="pgsodium"
     [pgsphere]="pg_sphere"


### PR DESCRIPTION
## Summary

Adds [pgmq](https://github.com/pgmq/pgmq) — a lightweight Postgres message queue (like AWS SQS / RSMQ).

Per the request, I checked APT availability first: **pgmq is not published in the PGDG apt repo** for any supported PG major (17, 18, 19), so it is built **from source** at the latest stable tag **v1.12.0**.

## Details

- **Pure SQL/plpgsql extension** — no C source, no `.so` (verified: 0 `LANGUAGE c` functions). The bundling/normalizer stages are effectively no-ops.
- Source lives in the `pgmq-extension/` subdirectory; the Dockerfile runs `make` (generates the versioned `sql/pgmq--1.12.0.sql`) then `make install`, following the classic/normalizer/isolated layout pattern.
- **License:** PostgreSQL (permissive → `ALLOW_LICENSES`, passes `make check-licenses`).
- Standard semver tags → picked up automatically by the source-build version monitor (no `TAG_FILTER` / `SKIP_MONITOR` needed).
- Core queue functionality needs no other extension; only optional *partitioned queues* require `pg_partman` (documented in `NOTES`), so no `DEPENDS` is forced — `CREATE EXTENSION pgmq` works standalone.

## Files

- `extensions/pgmq/extension.conf` — source build pinned to `v1.12.0` for PG 17/18/19
- `extensions/pgmq/Dockerfile` — source build from the `pgmq-extension/` subdir
- `extensions/pgmq/test.sql` — 4 integration checks (schema/smoke, create+send, read-back, archive)
- `README.md` — extensions table row (alphabetical)
- `tests/test-layers.sh` — `[pgmq]="pgmq"` SQL name mapping (alphabetical)

## Testing

- `make check-licenses`: 80 ok, 0 rejected
- `make list`: pgmq shows `17 18 19` with correct description
- Full `tests/test-layers.sh` (collision, base-overwrite, self-containment, cross-layer leak, `CREATE EXTENSION`, integration) **passes on PG 17, 18, and 19** — 0 failures
- `shellcheck tests/test-layers.sh` clean