### PR TITLE
fix: publish combined profile images as multi-arch (arm64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,11 +587,8 @@ jobs:
     name: Profile ${{ matrix.profile }} (PG ${{ matrix.pg }})
     steps:
       - uses: actions/checkout@v7
-      - name: Tag beta image as major version
-        if: matrix.pg == '19'
-        run: |
-          docker pull postgres:19beta1
-          docker tag postgres:19beta1 postgres:19
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -599,10 +596,10 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push profile image
+      - name: Build and push multi-arch profile image
         run: |
           make image PG=${{ matrix.pg }} PROFILE=${{ matrix.profile }} \
-            REGISTRY=${{ env.REGISTRY }}/${{ github.repository_owner }}
-          docker tag pglayers-${{ matrix.profile }}:${{ matrix.pg }} \
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/pglayers-${{ matrix.profile }}:${{ matrix.pg }}
-          docker push ${{ env.REGISTRY }}/${{ github.repository_owner }}/pglayers-${{ matrix.profile }}:${{ matrix.pg }}
+            PG_TAG=${{ matrix.pg == '19' && '19beta1' || matrix.pg }} \
+            REGISTRY=${{ env.REGISTRY }}/${{ github.repository_owner }} \
+            IMAGE_TAG=${{ env.REGISTRY }}/${{ github.repository_owner }}/pglayers-${{ matrix.profile }}:${{ matrix.pg }} \
+            PLATFORM=linux/amd64,linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ endif
 # Default: native architecture only (fast local builds).
 PLATFORM ?=
 
-.PHONY: help list build build-all image push push-all dockerfile clean clean-all test test-image list-profiles check-profiles check-licenses add-apt-ext
+.PHONY: help list build build-all image push push-all dockerfile clean clean-all test test-image verify-multiarch list-profiles check-profiles check-licenses add-apt-ext
 
 help: ## Show this help
 	@printf "Usage:\n"
@@ -369,6 +369,7 @@ image: ## Build a combined image with all extensions
 			-f "$$TMPFILE" \
 			--push \
 			.; \
+		./scripts/verify-multiarch.sh $(IMAGE_TAG) $(subst $(comma), ,$(PLATFORM)); \
 	else \
 		docker build -t $(IMAGE_TAG) -f "$$TMPFILE" .; \
 	fi; \
@@ -404,6 +405,10 @@ test: ## Run layer collision and functional tests
 
 test-image: ## Run integration tests against the combined image
 	@./tests/test-image.sh $(IMAGE_NAME):$(PG)
+
+# PLATFORM defaults to amd64+arm64; override to check a different set.
+verify-multiarch: ## Assert a pushed image is a multi-arch manifest (IMAGE_TAG=..., PLATFORM=...)
+	@./scripts/verify-multiarch.sh $(IMAGE_TAG) $(if $(PLATFORM),$(subst $(comma), ,$(PLATFORM)),linux/amd64 linux/arm64)
 
 test-k8s: ## Run Kubernetes ImageVolume integration test (requires k3d, PG 18+)
 	@./tests/test-k8s.sh $(REGISTRY) $(PG)

--- a/Makefile
+++ b/Makefile
@@ -253,8 +253,18 @@ add-apt-ext: ## Scaffold a new APT extension (PKG=<apt package> [NAME=<dir>] [PG
 	echo "  - build: make build EXT=$$name PG=$$pg REGISTRY=local"
 
 IMAGE_NAME ?= pglayers$(if $(PROFILE),-$(PROFILE))
+# Final tag for the combined image. Defaults to the local <name>:<pg> tag; CI
+# overrides it with the fully-qualified registry path it pushes to.
+IMAGE_TAG  ?= $(IMAGE_NAME):$(PG)
 
 image: ## Build a combined image with all extensions
+	@# A multi-arch PLATFORM (e.g. linux/amd64,linux/arm64) builds with buildx and
+	@# pushes straight to the registry: buildx cannot --load a multi-platform
+	@# manifest, and its container driver only resolves the COPY --from extension
+	@# layers / base image from a registry -- so this path requires
+	@# REGISTRY=<registry> (multi-arch layers already published there). A
+	@# single/empty PLATFORM uses classic docker build against the local store,
+	@# as before (works with REGISTRY=local layers for tests/local dev).
 	@echo "Building combined image $(IMAGE_NAME):$(PG)..."
 	@TMPFILE=$$(mktemp); \
 	skipped=""; \
@@ -264,7 +274,7 @@ image: ## Build a combined image with all extensions
 	total=0; \
 	included_exts=""; \
 	{ \
-		echo "FROM postgres:$(PG)"; \
+		echo "FROM postgres:$(or $(PG_TAG),$(PG))"; \
 		for ext in $(EXTENSIONS); do \
 			ver=$$(./scripts/ext-version.sh "$$ext" "$(PG)"); \
 			[ -z "$$ver" ] && continue; \
@@ -352,9 +362,18 @@ image: ## Build a combined image with all extensions
 	else \
 		echo "Included $$included/$$total extensions"; \
 	fi; \
-	docker build -t $(IMAGE_NAME):$(PG) -f "$$TMPFILE" .; \
+	if [ -n "$(findstring $(comma),$(PLATFORM))" ]; then \
+		docker buildx build \
+			--platform $(PLATFORM) \
+			-t $(IMAGE_TAG) \
+			-f "$$TMPFILE" \
+			--push \
+			.; \
+	else \
+		docker build -t $(IMAGE_TAG) -f "$$TMPFILE" .; \
+	fi; \
 	rm -f "$$TMPFILE"
-	@echo "Done: $(IMAGE_NAME):$(PG)"
+	@echo "Done: $(IMAGE_TAG)"
 
 clean: _check-ext ## Remove built image for a single extension
 	@for pg in $(PG_VERSIONS); do \

--- a/scripts/verify-multiarch.sh
+++ b/scripts/verify-multiarch.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Assert that a pushed image is a multi-arch manifest list containing every
+# required platform.
+#
+# The combined profile images (pglayers-full, pglayers-azure) are composed from
+# the per-arch extension layers and pushed as a single manifest list. A single-
+# arch push (e.g. building without buildx, or a layer that only exists for one
+# arch) silently produces an image that fails at `docker pull` time on the
+# missing platform with "does not provide the specified platform" -- the failure
+# reported in #50. This check runs right after the push so that regression is
+# caught in CI instead of by users.
+#
+# Usage:
+#   verify-multiarch.sh <image-ref> [platform ...]
+# Platforms default to linux/amd64 linux/arm64 when none are given. Extra
+# attestation manifests (platform architecture "unknown") are ignored.
+set -eu
+
+IMAGE="${1:?usage: verify-multiarch.sh <image-ref> [platform ...]}"
+shift || true
+if [ "$#" -gt 0 ]; then
+  REQUIRED=("$@")
+else
+  REQUIRED=(linux/amd64 linux/arm64)
+fi
+
+echo "Verifying multi-arch manifest: $IMAGE"
+
+raw="$(docker buildx imagetools inspect --raw "$IMAGE")"
+
+# Real (non-attestation) platforms declared in the manifest list. A single-image
+# manifest has no .manifests[] and yields an empty list here.
+present="$(printf '%s' "$raw" | jq -r '
+  (.manifests // [])[]
+  | select((.platform.architecture // "unknown") != "unknown")
+  | "\(.platform.os)/\(.platform.architecture)"
+' | sort -u)"
+
+if [ -z "$present" ]; then
+  echo "ERROR: $IMAGE is not a multi-arch manifest list (single-platform image)." >&2
+  exit 1
+fi
+
+echo "Platforms present:"
+# shellcheck disable=SC2086 # intentional word-split: one platform per line
+printf '  - %s\n' $present
+
+missing=""
+for want in "${REQUIRED[@]}"; do
+  if ! printf '%s\n' "$present" | grep -qxF "$want"; then
+    missing="${missing:+$missing }$want"
+  fi
+done
+
+if [ -n "$missing" ]; then
+  echo "ERROR: $IMAGE is missing required platform(s): $missing" >&2
+  exit 1
+fi
+
+echo "OK: $IMAGE provides all required platforms: ${REQUIRED[*]}"


### PR DESCRIPTION
## Problem

Fixes #50. Pulling `ghcr.io/pglayers/pglayers-full:18` (or any `pglayers-*` profile image) on `linux/arm64` fails:

```
image with reference ghcr.io/pglayers/pglayers-full:18 was found but does not provide the specified platform (linux/arm64)
```

## Root cause

The per-extension `pgx-*` layers are published as proper multi-arch manifests (per-arch native builds merged in the `manifest` job). But the **combined profile images** (`pglayers-full`, `pglayers-azure`) were built with plain `docker build` in the Makefile `image` target, producing a single-arch (amd64) image. The `profile-images` CI job then just `docker tag`/`docker push`ed that amd64-only image.

## Fix

**`Makefile` `image` target**
- Add `IMAGE_TAG` var (defaults to local `<name>:<pg>`, overridable with a fully-qualified registry path).
- When `PLATFORM` lists multiple arches, build with `docker buildx build --platform ... --push` (buildx can't `--load` a multi-platform manifest; its container driver resolves the `COPY --from` layers / base image from a registry). A single/empty `PLATFORM` keeps the classic `docker build` against the local store, so `REGISTRY=local` tests/dev builds are unchanged.
- Base `FROM` now honors `PG_TAG` (`$(or $(PG_TAG),$(PG))`) so the PG 19 beta base resolves from the registry instead of a local retag the buildx container driver can't see.

**`.github/workflows/ci.yml` `profile-images` job**
- Add `docker/setup-qemu-action@v4` (arm64 RUN steps run under emulation — all trivial shell).
- Replace tag-then-push with a single multi-arch `make image ... PLATFORM=linux/amd64,linux/arm64 IMAGE_TAG=<ghcr path>`, passing `PG_TAG=19beta1` for PG 19.

## Post-build validation

- New `scripts/verify-multiarch.sh`: inspects a pushed image's manifest list and fails if it's single-platform or missing a required platform (default `linux/amd64` + `linux/arm64`) — the exact #50 failure mode.
- Wired into the multi-arch branch of `make image`, so every `buildx --push` self-validates (the `profile-images` job now checks itself; no separate step to forget).
- Standalone `make verify-multiarch IMAGE_TAG=...` to re-check already-published images.

## Notes

- Already-published `pglayers-*` manifests stay amd64-only until this lands and `profile-images` re-runs on `main` (next merge or manual `workflow_dispatch`), which republishes them as multi-arch.
- Verified: local single-arch build still works end-to-end; both Makefile branches expand correctly; `verify-multiarch.sh` passes on a real multi-arch image, fails on a missing platform, and is shellcheck-clean; workflow YAML validated.