### PR TITLE
chore: bump PG 19 base image to 19beta2 + retry transient GHCR failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,37 +275,48 @@ jobs:
         run: ./scripts/ci-free-disk.sh
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Single quotes are intentional: the token must expand inside sh -c on
+          # each retry attempt, not once when the outer shell parses the line.
+          # shellcheck disable=SC2016
+          ./scripts/ci-retry.sh -n 4 -w 15 sh -c \
+            'echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin'
       - name: Build and push per-arch staging image
-        uses: docker/build-push-action@v7
-        with:
-          context: extensions/${{ matrix.extension }}
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/${{ matrix.arch }}
-          build-args: |
-            PG_MAJOR=${{ matrix.pg }}
-            PG_TAG=${{ matrix.pg == '19' && '19beta2' || matrix.pg }}
-            EXT_VERSION=${{ matrix.version }}
-            EXT_NAME=${{ matrix.extension }}
-            LAYOUT=${{ matrix.pg >= 18 && 'isolated' || 'classic' }}
-          push: true
-          # Immutable per-version, per-arch staging tag -- never the public :<pg>.
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:${{ matrix.pg }}-${{ matrix.version }}-${{ matrix.arch }}
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}
+        run: |
           # Registry-only cache. The type=gha cache is deliberately NOT used: on
           # a full rebuild (build_all) hundreds of jobs share the repo's 10 GB
           # GHA cache, which evicts entries mid-build ("cache entry no longer
           # exists"). The GHCR buildcache has no such cap and gives the same
           # cross-run reuse.
-          cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-${{ matrix.arch }}
-            ${{ matrix.extension == 'plv8' && format('type=registry,ref={0}/{1}/plv8-v8:{2}', env.REGISTRY, github.repository_owner, matrix.version) || '' }}
-            ${{ matrix.vcpkg_version != '' && format('type=registry,ref={0}/{1}/pg-lake-vcpkg:{2}', env.REGISTRY, github.repository_owner, matrix.vcpkg_version) || '' }}
-          cache-to: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-${{ matrix.arch }},mode=max
+          cache_from="--cache-from type=registry,ref=${IMAGE}:buildcache-${{ matrix.pg }}-${{ matrix.arch }}"
+          if [ "${{ matrix.extension }}" = plv8 ]; then
+            cache_from="$cache_from --cache-from type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/plv8-v8:${{ matrix.version }}"
+          fi
+          if [ -n "${{ matrix.vcpkg_version }}" ]; then
+            cache_from="$cache_from --cache-from type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/pg-lake-vcpkg:${{ matrix.vcpkg_version }}"
+          fi
+          # ci-retry retries transient GHCR auth/push failures (denied / 403 /
+          # oauth token) that hit a handful of jobs on a full-rebuild fan-out.
+          # $cache_from is intentionally word-split into separate --cache-from flags.
+          # shellcheck disable=SC2086
+          ./scripts/ci-retry.sh docker buildx build \
+            --platform linux/${{ matrix.arch }} \
+            --build-arg PG_MAJOR=${{ matrix.pg }} \
+            --build-arg PG_TAG=${{ matrix.pg == '19' && '19beta2' || matrix.pg }} \
+            --build-arg EXT_VERSION=${{ matrix.version }} \
+            --build-arg EXT_NAME=${{ matrix.extension }} \
+            --build-arg LAYOUT=${{ matrix.pg >= 18 && 'isolated' || 'classic' }} \
+            --file ${{ matrix.dockerfile }} \
+            --tag ${IMAGE}:${{ matrix.pg }}-${{ matrix.version }}-${{ matrix.arch }} \
+            $cache_from \
+            --cache-to type=registry,ref=${IMAGE}:buildcache-${{ matrix.pg }}-${{ matrix.arch }},mode=max \
+            --push \
+            extensions/${{ matrix.extension }}
 
   build-apt:
     needs: matrix
@@ -330,31 +341,36 @@ jobs:
         uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Single quotes are intentional: the token must expand inside sh -c on
+          # each retry attempt, not once when the outer shell parses the line.
+          # shellcheck disable=SC2016
+          ./scripts/ci-retry.sh -n 4 -w 15 sh -c \
+            'echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin'
       - name: Build and push multi-arch staging image
-        uses: docker/build-push-action@v7
-        with:
-          context: extensions/${{ matrix.extension }}
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            PG_MAJOR=${{ matrix.pg }}
-            PG_TAG=${{ matrix.pg == '19' && '19beta2' || matrix.pg }}
-            EXT_VERSION=${{ matrix.version }}
-            APT_PACKAGE=${{ matrix.apt_package }}
-            EXT_NAME=${{ matrix.extension }}
-            LAYOUT=${{ matrix.pg >= 18 && 'isolated' || 'classic' }}
-          push: true
-          # Immutable, multi-arch per-version staging tag -- never the public :<pg>.
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:${{ matrix.pg }}-${{ matrix.version }}
-          cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-all
-          cache-to: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}:buildcache-${{ matrix.pg }}-all,mode=max
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.PREFIX }}-${{ matrix.extension }}
+        run: |
+          # ci-retry retries transient GHCR auth/push failures (denied / 403 /
+          # oauth token) that hit a handful of jobs on a full-rebuild fan-out.
+          # shellcheck disable=SC2086 # IMAGE is a controlled ref, no splitting risk
+          ./scripts/ci-retry.sh docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg PG_MAJOR=${{ matrix.pg }} \
+            --build-arg PG_TAG=${{ matrix.pg == '19' && '19beta2' || matrix.pg }} \
+            --build-arg EXT_VERSION=${{ matrix.version }} \
+            --build-arg APT_PACKAGE=${{ matrix.apt_package }} \
+            --build-arg EXT_NAME=${{ matrix.extension }} \
+            --build-arg LAYOUT=${{ matrix.pg >= 18 && 'isolated' || 'classic' }} \
+            --file ${{ matrix.dockerfile }} \
+            --tag ${IMAGE}:${{ matrix.pg }}-${{ matrix.version }} \
+            --cache-from type=registry,ref=${IMAGE}:buildcache-${{ matrix.pg }}-all \
+            --cache-to type=registry,ref=${IMAGE}:buildcache-${{ matrix.pg }}-all,mode=max \
+            --push \
+            extensions/${{ matrix.extension }}
 
   # ---------------------------------------------------------------------------
   # Layer + combined-image tests (collision, self-containment, cross-layer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           build-args: |
             PG_MAJOR=${{ matrix.pg }}
-            PG_TAG=${{ matrix.pg == '19' && '19beta1' || matrix.pg }}
+            PG_TAG=${{ matrix.pg == '19' && '19beta2' || matrix.pg }}
             EXT_VERSION=${{ matrix.version }}
             EXT_NAME=${{ matrix.extension }}
             LAYOUT=${{ matrix.pg >= 18 && 'isolated' || 'classic' }}
@@ -343,7 +343,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             PG_MAJOR=${{ matrix.pg }}
-            PG_TAG=${{ matrix.pg == '19' && '19beta1' || matrix.pg }}
+            PG_TAG=${{ matrix.pg == '19' && '19beta2' || matrix.pg }}
             EXT_VERSION=${{ matrix.version }}
             APT_PACKAGE=${{ matrix.apt_package }}
             EXT_NAME=${{ matrix.extension }}
@@ -388,8 +388,8 @@ jobs:
       - name: Tag beta image as major version
         if: matrix.pg == '19'
         run: |
-          docker pull postgres:19beta1
-          docker tag postgres:19beta1 postgres:19
+          docker pull postgres:19beta2
+          docker tag postgres:19beta2 postgres:19
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -401,7 +401,7 @@ jobs:
         env:
           SOURCE_REGISTRY: ${{ env.REGISTRY }}/${{ github.repository_owner }}
           PREFIX: ${{ env.PREFIX }}
-          PG_TAG: ${{ matrix.pg == '19' && '19beta1' || matrix.pg }}
+          PG_TAG: ${{ matrix.pg == '19' && '19beta2' || matrix.pg }}
           CHANGED: ${{ needs.matrix.outputs.changed }}
           DOCKER_BUILDKIT: '1'
         run: |
@@ -410,7 +410,7 @@ jobs:
           ./scripts/ci-prepare-images.sh ${{ matrix.pg }} $exts
       - name: Run test suite
         env:
-          PG_TAG: ${{ matrix.pg == '19' && '19beta1' || matrix.pg }}
+          PG_TAG: ${{ matrix.pg == '19' && '19beta2' || matrix.pg }}
         run: make test REGISTRY=local PG=${{ matrix.pg }} PG_TAG="$PG_TAG"
 
   # ---------------------------------------------------------------------------
@@ -443,8 +443,8 @@ jobs:
       - name: Tag beta image as major version
         if: matrix.pg == '19'
         run: |
-          docker pull postgres:19beta1
-          docker tag postgres:19beta1 postgres:19
+          docker pull postgres:19beta2
+          docker tag postgres:19beta2 postgres:19
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -456,7 +456,7 @@ jobs:
         env:
           SOURCE_REGISTRY: ${{ env.REGISTRY }}/${{ github.repository_owner }}
           PREFIX: ${{ env.PREFIX }}
-          PG_TAG: ${{ matrix.pg == '19' && '19beta1' || matrix.pg }}
+          PG_TAG: ${{ matrix.pg == '19' && '19beta2' || matrix.pg }}
           CHANGED: ${{ needs.matrix.outputs.changed }}
           DOCKER_BUILDKIT: '1'
         run: |
@@ -599,7 +599,7 @@ jobs:
       - name: Build and push multi-arch profile image
         run: |
           make image PG=${{ matrix.pg }} PROFILE=${{ matrix.profile }} \
-            PG_TAG=${{ matrix.pg == '19' && '19beta1' || matrix.pg }} \
+            PG_TAG=${{ matrix.pg == '19' && '19beta2' || matrix.pg }} \
             REGISTRY=${{ env.REGISTRY }}/${{ github.repository_owner }} \
             IMAGE_TAG=${{ env.REGISTRY }}/${{ github.repository_owner }}/pglayers-${{ matrix.profile }}:${{ matrix.pg }} \
             PLATFORM=linux/amd64,linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ add-apt-ext: ## Scaffold a new APT extension (PKG=<apt package> [NAME=<dir>] [PG
 	@test -n "$(PKG)" || { echo "Usage: make add-apt-ext PKG=<apt package> [NAME=<dir>] [PG=17]"; exit 1; }
 	@name="$(or $(NAME),$(subst -,_,$(PKG)))"; \
 	pg="$(or $(PG),17)"; \
-	pgtag="$$pg"; [ "$$pg" = "19" ] && pgtag="19beta1"; \
+	pgtag="$$pg"; [ "$$pg" = "19" ] && pgtag="19beta2"; \
 	dir="extensions/$$name"; \
 	if [ -e "$$dir" ]; then echo "Error: $$dir already exists"; exit 1; fi; \
 	echo "Probing PGDG for postgresql-$$pg-$(PKG)..."; \

--- a/README.md
+++ b/README.md
@@ -685,8 +685,8 @@ make build EXT=pgvector PG=17
 make build-all PG=17
 
 # Build for PG 19 (beta -- requires PG_TAG override until GA)
-make build EXT=pgvector PG=19 PG_TAG=19beta1
-make build-all PG=19 PG_TAG=19beta1
+make build EXT=pgvector PG=19 PG_TAG=19beta2
+make build-all PG=19 PG_TAG=19beta2
 
 # Build a combined image with ALL extensions included
 make image PG=17 REGISTRY=local

--- a/scripts/apt-support.sh
+++ b/scripts/apt-support.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 CACHE_DIR="${PGLAYERS_APT_CACHE_DIR:-/tmp/pglayers-apt-cache}"
 
-_pg_tag() { [ "$1" = "19" ] && echo "19beta1" || echo "$1"; }
+_pg_tag() { [ "$1" = "19" ] && echo "19beta2" || echo "$1"; }
 
 # Debian apt version -> clean, docker-tag-safe upstream version.
 # e.g. 0.8.5-1.pgdg13+1 -> 0.8.5 ; 3.6.4+dfsg-2.pgdg13+1 -> 3.6.4

--- a/scripts/ci-retry.sh
+++ b/scripts/ci-retry.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Run a command, retrying on failure with exponential backoff.
+#
+# GHCR intermittently returns transient auth/push errors under the concurrency
+# of a full rebuild -- "denied: denied", "failed to fetch oauth token",
+# "failed to push ...: 403 Forbidden", "failed to configure registry cache
+# importer". These are not real permission problems (sibling jobs pushing to the
+# same registry with the same token succeed); a short retry clears them and
+# avoids a manual re-run of the whole workflow. See issue #50 / PR CI history.
+#
+# Usage:
+#   ci-retry.sh [-n attempts] [-w seconds] <command> [args...]
+#
+#   -n  max attempts     (default 3)
+#   -w  initial backoff  (default 20s; doubles after each failed attempt)
+#
+# The command is re-executed verbatim on each attempt, so it must be idempotent
+# (docker login, buildx build --push, and imagetools create all are).
+set -uo pipefail
+
+attempts=3
+wait=20
+while getopts ":n:w:" opt; do
+  case "$opt" in
+    n) attempts="$OPTARG" ;;
+    w) wait="$OPTARG" ;;
+    *) echo "ci-retry: unknown option -$OPTARG" >&2; exit 2 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: ci-retry.sh [-n attempts] [-w seconds] <command> [args...]" >&2
+  exit 2
+fi
+
+i=1
+while true; do
+  "$@" && exit 0
+  status=$?
+  if [ "$i" -ge "$attempts" ]; then
+    echo "ci-retry: '$*' failed after $i attempt(s) (exit $status)" >&2
+    exit "$status"
+  fi
+  echo "ci-retry: attempt $i/$attempts failed (exit $status); retrying in ${wait}s..." >&2
+  sleep "$wait"
+  i=$((i + 1))
+  wait=$((wait * 2))
+done

--- a/scripts/detect-license.sh
+++ b/scripts/detect-license.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 pg="${1:?usage: detect-license.sh <pg> <apt_package>}"
 pkg="${2:?usage: detect-license.sh <pg> <apt_package>}"
-tag="$pg"; [ "$pg" = "19" ] && tag="19beta1"
+tag="$pg"; [ "$pg" = "19" ] && tag="19beta2"
 
 # Fetch the whole copyright file once. Distinguish an infrastructure failure
 # (docker/apt error -> fail fast, non-zero) from a package that installs but


### PR DESCRIPTION
## What

Two related changes (rebased on top of `main`, which now includes the multi-arch profile-image fix from #57):

### 1. Bump PG 19 base image `19beta1` -> `19beta2`

The official `postgres:19` image advanced from 19beta1 to 19beta2. Updates every `PG_TAG` override that pins the beta base tag:
- `.github/workflows/ci.yml` — all `PG_TAG=19beta1` overrides.
- `scripts/apt-support.sh`, `scripts/detect-license.sh` — the PG-19-to-beta-tag helpers.
- `Makefile` — the PGDG version-probe tag mapping.
- `README.md` — the PG 19 build examples.

Generic "beta" support-status wording in the README is intentionally left unchanged — only version-pinned `19beta1` tags were bumped.

### 2. Retry transient GHCR auth/push failures in the build jobs

A full-rebuild PR fans out the entire build matrix, and a handful of jobs intermittently hit transient GHCR errors — `denied: denied` (login), `403 Forbidden` (push), `failed to fetch oauth token`, cache-importer auth denied — that failed the whole run and needed a manual re-run, even though sibling jobs pushed to the same registry with the same token successfully (observed on the #57 run: 6/243 jobs).

- Add `scripts/ci-retry.sh`: run a command with exponential backoff (default 3 attempts).
- Wrap the GHCR **login** and the buildx **build+push** in `build-native` and `build-apt` with it. The build steps move from `docker/build-push-action` to an equivalent `docker buildx build --push` so the actual push — not just the login — is retried. Platforms, build-args, tags, `--file`/context, and registry cache refs are preserved verbatim.

## Validation

- `shellcheck` clean on `scripts/ci-retry.sh` (+ functional test of the backoff/exhaustion paths).
- `actionlint` clean on `ci.yml` (intentional SC2016/SC2086 patterns annotated).
- `ci.yml` YAML parses.

## Notes

- PG 19 remains best-effort/non-blocking (`continue-on-error`) in CI until GA; no `VERSION_XX` to bump (APT extensions resolve from PGDG).
- The other push-capable jobs (`manifest`, `profile-images`) still use `docker/login-action`; scope was kept to the build jobs where the failures occurred. Easy to extend later if needed.