### PR TITLE
feat: add pg_clickhouse (ClickHouse FDW) + pg_re2 (RE2 regex) extensions

### DIFF
--- a/.github/workflows/monitor-extensions.yml
+++ b/.github/workflows/monitor-extensions.yml
@@ -204,6 +204,16 @@ jobs:
                   | tail -1) || true
                 [ -n "$pg_latest" ] && new_ver="$pg_latest"
               fi
+              # Preserve the conf's existing tag-prefix convention. Some
+              # upstreams tag releases as vX.Y.Z but publish the artifact the
+              # Dockerfile consumes (e.g. a Docker image tag) as X.Y.Z. When the
+              # pinned VERSION_XX is stored without a leading "v", keep it v-less
+              # so the bumped value still matches that artifact (e.g.
+              # pg_clickhouse -> ghcr.io/clickhouse/pg_clickhouse:<pg>-X.Y.Z).
+              case "$old_ver" in
+                v*) ;;
+                *)  new_ver="${new_ver#v}" ;;
+              esac
               sed -i "s|^VERSION_${pg}=.*|VERSION_${pg}=\"${new_ver}\"|" "$conf_file"
             done
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ promoted to stable.
 | [pg_statviz](https://github.com/vyruss/pg_statviz) | 1.1 | 17, 18, 19 | Time-series snapshots of PostgreSQL statistics for visualization |
 | [pgaudit](https://github.com/pgaudit/pgaudit) | 17.1 | 17, 18 | Audit logging (session and object-level) |
 | [pg_bigm](https://github.com/pgbigm/pg_bigm) | 1.2 | 17, 18 | 2-gram full text search (better for CJK languages) |
-| [pg_clickhouse](https://github.com/ClickHouse/pg_clickhouse) | 0.10.0 | 17, 18 | Query ClickHouse databases from PostgreSQL (FDW with pushdown; bundles the `re2` companion extension) |
+| [pg_clickhouse](https://github.com/ClickHouse/pg_clickhouse) | 0.10.0 | 17, 18 | Query ClickHouse databases from PostgreSQL (FDW with pushdown; depends on `re2` for regex pushdown) |
 | [pg_cron](https://github.com/citusdata/pg_cron) | 1.6.7 | 17, 18 | Job scheduler (periodic jobs inside the database) |
 | [pg_duckdb](https://github.com/duckdb/pg_duckdb) | 1.1.1 | 17, 18 | DuckDB columnar analytics engine embedded in Postgres |
 | [pg_durable](https://github.com/microsoft/pg_durable) | 0.2.3 | 17, 18 | In-database durable execution (fault-tolerant workflows) |
@@ -170,6 +170,7 @@ promoted to stable.
 | [pg_partman](https://github.com/pgpartman/pg_partman) | 5.4.3 | 17, 18, 19 | Automated table partition management |
 | [pg_permissions](https://github.com/cybertec-postgresql/pg_permissions) | 1.4.1 | 17, 18, 19 | Review and audit object permissions against a desired state |
 | [pg_qualstats](https://github.com/powa-team/pg_qualstats) | 2.1.4 | 17, 18, 19 | Statistics collector for WHERE clause predicates |
+| [pg_re2](https://github.com/ClickHouse/pg_re2) | 0.4.1 | 17, 18, 19 | ClickHouse-compatible regex functions using RE2 |
 | [pg_repack](https://github.com/reorg/pg_repack) | 1.5.3 | 17, 18, 19 | Online table reorganization without heavy locks |
 | [pg_roaringbitmap](https://github.com/ChenHuajun/pg_roaringbitmap) | 1.2.0 | 17, 18 | Roaring bitmap data type for fast set operations |
 | [pg_rrule](https://github.com/Natureshadow/pg_rrule) | 0.3.0 | 17, 18, 19 | iCalendar RRULE recurrence type and occurrence expansion |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ promoted to stable.
 | [pg_statviz](https://github.com/vyruss/pg_statviz) | 1.1 | 17, 18, 19 | Time-series snapshots of PostgreSQL statistics for visualization |
 | [pgaudit](https://github.com/pgaudit/pgaudit) | 17.1 | 17, 18 | Audit logging (session and object-level) |
 | [pg_bigm](https://github.com/pgbigm/pg_bigm) | 1.2 | 17, 18 | 2-gram full text search (better for CJK languages) |
+| [pg_clickhouse](https://github.com/ClickHouse/pg_clickhouse) | 0.10.0 | 17, 18 | Query ClickHouse databases from PostgreSQL (FDW with pushdown; bundles the `re2` companion extension) |
 | [pg_cron](https://github.com/citusdata/pg_cron) | 1.6.7 | 17, 18 | Job scheduler (periodic jobs inside the database) |
 | [pg_duckdb](https://github.com/duckdb/pg_duckdb) | 1.1.1 | 17, 18 | DuckDB columnar analytics engine embedded in Postgres |
 | [pg_durable](https://github.com/microsoft/pg_durable) | 0.2.3 | 17, 18 | In-database durable execution (fault-tolerant workflows) |

--- a/extensions/pg_clickhouse/Dockerfile
+++ b/extensions/pg_clickhouse/Dockerfile
@@ -1,0 +1,181 @@
+# syntax=docker/dockerfile:1
+ARG PG_MAJOR=17
+ARG PG_TAG=${PG_MAJOR}
+ARG LAYOUT=classic
+ARG EXT_VERSION=0.10.0
+
+# Use ClickHouse's official pre-built pg_clickhouse image (avoids compiling the
+# extension + the RE2/abseil dependency stack). Same approach as pg_duckdb.
+# NOTE: upstream tags the image WITHOUT a leading "v" (e.g. 18-0.10.0), so
+# EXT_VERSION/VERSION_XX are stored v-less to match this tag directly.
+FROM ghcr.io/clickhouse/pg_clickhouse:${PG_MAJOR}-${EXT_VERSION} AS upstream
+
+# Snapshot base image libraries for diffing (by soname, not canonical path)
+FROM postgres:${PG_TAG} AS base
+RUN find /usr/lib -name '*.so*' \( -type f -o -type l \) 2>/dev/null \
+    | sed 's|.*/||' | sort -u > /tmp/base-libs.txt
+
+# Collector: extract extensions + bundle missing runtime deps.
+# The upstream image ships two extensions in one layer: pg_clickhouse (the FDW)
+# and re2 (its recommended companion, ClickHouse-compatible RE2 regex functions
+# used for regex pushdown). We ship both, exactly as upstream packages them.
+FROM upstream AS collector
+ARG PG_MAJOR
+COPY --from=base /tmp/base-libs.txt /tmp/base-libs.txt
+
+USER root
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends patchelf
+
+# Copy extension artifacts (both pg_clickhouse and re2) to /output
+RUN set -eux; \
+    PG=${PG_MAJOR}; \
+    LIB="/usr/lib/postgresql/${PG}/lib"; \
+    SHARE="/usr/share/postgresql/${PG}/extension"; \
+    mkdir -p "/output${LIB}/bitcode" \
+             "/output${SHARE}"; \
+    cp "${LIB}/pg_clickhouse.so" "/output${LIB}/"; \
+    cp "${LIB}/re2.so" "/output${LIB}/"; \
+    cp "${SHARE}"/pg_clickhouse* "/output${SHARE}/"; \
+    cp "${SHARE}"/re2* "/output${SHARE}/"; \
+    # Bitcode: per-extension index files + the pg_clickhouse subtree. Copy only
+    # our files so we never overwrite the base image's bitcode entries.
+    for bc in "${LIB}/bitcode/pg_clickhouse.index.bc" \
+              "${LIB}/bitcode/re2.index.bc"; do \
+        [ -f "$bc" ] && cp "$bc" "/output${LIB}/bitcode/"; \
+    done; \
+    [ -d "${LIB}/bitcode/pg_clickhouse" ] && \
+        cp -r "${LIB}/bitcode/pg_clickhouse" "/output${LIB}/bitcode/" || true
+
+# Bundle ALL runtime shared libraries that pg_clickhouse/re2 need but the base
+# postgres image doesn't have (libcurl + transitive brotli/nghttp/ssh2/rtmp/psl,
+# and re2's libre2 + the whole libabsl_* / libstdc++ stack), so the layer is
+# fully self-contained (never rely on a sibling layer to provide libcurl et al.).
+# Compare by soname to avoid bundling older versions of libs already in the base
+# image. Collisions in the flat classic layout are prevented later by relocating
+# these into a private dir with RUNPATH + mangled sonames.
+RUN set -eux; \
+    PG=${PG_MAJOR}; \
+    ldd /usr/lib/postgresql/${PG}/lib/pg_clickhouse.so \
+        /usr/lib/postgresql/${PG}/lib/re2.so 2>/dev/null \
+        | awk '/=>/ && /\// {print $3}' | sort -u > /tmp/all-deps.txt; \
+    while IFS= read -r lib; do \
+        soname="$(basename "$lib")"; \
+        if grep -qxF "$soname" /tmp/base-libs.txt 2>/dev/null; then \
+            continue; \
+        fi; \
+        dest="$(echo "$lib" | sed 's|^/lib/|/usr/lib/|')"; \
+        mkdir -p "/output$(dirname "$dest")"; \
+        cp -aL "$lib" "/output${dest}" 2>/dev/null || true; \
+    done < /tmp/all-deps.txt; \
+    find /output -name '*.so*' -type f -exec strip --strip-unneeded {} \; 2>/dev/null || true
+
+# --- Layout selection ---
+# Classic (PG 17): relocate bundled deps into an extension-private directory
+# and point each ELF object's RUNPATH at it via $ORIGIN. Keeps the flat layout
+# self-contained AND collision-free (private dir name is unique per ext).
+FROM collector AS classic-relocate
+ARG PG_MAJOR
+RUN set -eux; \
+    PG=${PG_MAJOR}; \
+    EXT=pg_clickhouse; \
+    LIBDIR="/output/usr/lib/postgresql/${PG}/lib"; \
+    DEPS_DIR="${LIBDIR}/${EXT}-deps"; \
+    tag="pglx_${EXT}_"; \
+    mkdir -p "$DEPS_DIR"; \
+    find /output/usr/lib -path '/output/usr/lib/postgresql' -prune -o \
+        -name '*.so*' \( -type f -o -type l \) -print \
+        | while IFS= read -r lib; do mv "$lib" "$DEPS_DIR/"; done; \
+    # Mangle each bundled dep's soname with a per-extension prefix. sonames are
+    # process-global, so a private dir + RUNPATH alone does NOT isolate symbols:
+    # if a sibling extension loads its own libssh2.so.1 first, our libcurl would
+    # bind to it and hit undefined symbols. Unique sonames make cross-layer
+    # clashes impossible while keeping the layer self-contained.
+    find "$DEPS_DIR" -type l -delete 2>/dev/null || true; \
+    for dep in "$DEPS_DIR"/*.so*; do \
+        [ -f "$dep" ] || continue; \
+        soname="$(patchelf --print-soname "$dep" 2>/dev/null || true)"; \
+        [ -n "$soname" ] || soname="$(basename "$dep")"; \
+        patchelf --set-soname "${tag}${soname}" "$dep"; \
+        mv "$dep" "$DEPS_DIR/${tag}${soname}"; \
+    done; \
+    # Rewrite NEEDED refs to bundled libs across every ELF object we ship.
+    for obj in "$LIBDIR"/*.so* "$DEPS_DIR"/*.so*; do \
+        [ -f "$obj" ] || continue; \
+        for need in $(patchelf --print-needed "$obj" 2>/dev/null); do \
+            case "$need" in "${tag}"*) continue ;; esac; \
+            if [ -f "$DEPS_DIR/${tag}${need}" ]; then \
+                patchelf --replace-needed "$need" "${tag}${need}" "$obj"; \
+            fi; \
+        done; \
+    done; \
+    # Point RUNPATHs at the private dir ($ORIGIN for siblings + deps).
+    for so in "$LIBDIR"/*.so*; do \
+        [ -f "$so" ] || continue; \
+        patchelf --set-rpath "\$ORIGIN:\$ORIGIN/${EXT}-deps" "$so"; \
+    done; \
+    for dep in "$DEPS_DIR"/*.so*; do \
+        [ -f "$dep" ] || continue; \
+        patchelf --set-rpath '$ORIGIN' "$dep"; \
+    done; \
+    find /output/usr/lib -type d -empty -delete 2>/dev/null || true
+
+FROM scratch AS classic
+COPY --from=classic-relocate /output/ /
+
+# Isolated: flat /lib/ + /share/extension/ layout (PG 18+, CNPG-compatible).
+# Each extension resolves its OWN bundled deps from its private
+# /extensions/<ext>/lib via $ORIGIN RUNPATH -- never through a global ld.so
+# cache. Bundled-dep sonames are mangled with a per-extension prefix so two
+# layers that ship the same soname (e.g. libssh2.so.1 pulled in via libcurl by
+# both postgis and pg_clickhouse) can't clash in the shared postgres process.
+FROM collector AS normalizer
+ARG PG_MAJOR
+RUN set -eux; \
+    PG=${PG_MAJOR}; \
+    tag="pglx_pg_clickhouse_"; \
+    mkdir -p /isolated/lib /isolated/share/extension; \
+    find /output/usr/lib/postgresql/${PG}/lib -maxdepth 1 -type f \
+        -exec cp -a {} /isolated/lib/ \; ; \
+    cp -a /output/usr/share/postgresql/${PG}/extension/* /isolated/share/extension/; \
+    : > /tmp/bundled.txt; \
+    find /output/usr/lib -name '*.so*' ! -path '*/postgresql/*' \
+        \( -type f -o -type l \) 2>/dev/null | while IFS= read -r f; do \
+        cp -a "$f" /isolated/lib/ && basename "$f" >> /tmp/bundled.txt; \
+    done; \
+    cp -a /output/usr/lib/postgresql/${PG}/lib/bitcode /isolated/lib/bitcode \
+        2>/dev/null || true; \
+    if [ -s /tmp/bundled.txt ]; then \
+        sort -u /tmp/bundled.txt > /tmp/bundled-u.txt; \
+        while IFS= read -r name; do \
+            [ -L "/isolated/lib/$name" ] && rm -f "/isolated/lib/$name" || true; \
+        done < /tmp/bundled-u.txt; \
+        while IFS= read -r name; do \
+            dep="/isolated/lib/$name"; \
+            [ -f "$dep" ] || continue; \
+            soname="$(patchelf --print-soname "$dep" 2>/dev/null || true)"; \
+            [ -n "$soname" ] || soname="$name"; \
+            patchelf --set-soname "${tag}${soname}" "$dep"; \
+            mv "$dep" "/isolated/lib/${tag}${soname}"; \
+        done < /tmp/bundled-u.txt; \
+        for obj in /isolated/lib/*.so*; do \
+            [ -f "$obj" ] || continue; \
+            for need in $(patchelf --print-needed "$obj" 2>/dev/null); do \
+                case "$need" in "${tag}"*) continue ;; esac; \
+                if [ -f "/isolated/lib/${tag}${need}" ]; then \
+                    patchelf --replace-needed "$need" "${tag}${need}" "$obj"; \
+                fi; \
+            done; \
+        done; \
+    fi; \
+    for obj in /isolated/lib/*.so*; do \
+        [ -f "$obj" ] || continue; \
+        patchelf --set-rpath '$ORIGIN' "$obj"; \
+    done
+
+FROM scratch AS isolated
+COPY --from=normalizer /isolated/ /
+
+FROM ${LAYOUT}

--- a/extensions/pg_clickhouse/extension.conf
+++ b/extensions/pg_clickhouse/extension.conf
@@ -11,4 +11,5 @@ LICENSE="Apache-2.0"
 # convention on version bumps.
 VERSION_17="0.10.0"
 VERSION_18="0.10.0"
-NOTES="Foreign Data Wrapper for ClickHouse with WHERE/JOIN/aggregate pushdown. The layer also bundles the companion 're2' extension (ClickHouse-compatible RE2 regex functions) used for regex pushdown. Extracted from ClickHouse's official prebuilt image (like pg_duckdb). PG17/PG18 only -- upstream ships no PG19 image."
+DEPENDS="re2"
+NOTES="Foreign Data Wrapper for ClickHouse with WHERE/JOIN/aggregate pushdown. Extracted from ClickHouse's official prebuilt image (like pg_duckdb). Its recommended companion for regex pushdown, the 're2' extension, is shipped as a separate pglayers layer (extensions/pg_re2) and declared via DEPENDS. PG17/PG18 only -- upstream ships no PG19 image."

--- a/extensions/pg_clickhouse/extension.conf
+++ b/extensions/pg_clickhouse/extension.conf
@@ -1,0 +1,14 @@
+DESCRIPTION="Query ClickHouse databases from PostgreSQL (FDW with pushdown)"
+REPO="https://github.com/ClickHouse/pg_clickhouse.git"
+LICENSE="Apache-2.0"
+# Built from ClickHouse's official prebuilt image
+# (ghcr.io/clickhouse/pg_clickhouse:<pg>-<version>), same approach as pg_duckdb.
+# PG17/PG18 only: upstream publishes images for PG 13-18 (no PG 19 image yet).
+#
+# NOTE: upstream tags releases as vX.Y.Z but tags the Docker image as X.Y.Z
+# (no leading "v"), so VERSION_XX is stored WITHOUT the "v" to match the image
+# tag consumed by the Dockerfile. monitor-extensions.yml preserves this v-less
+# convention on version bumps.
+VERSION_17="0.10.0"
+VERSION_18="0.10.0"
+NOTES="Foreign Data Wrapper for ClickHouse with WHERE/JOIN/aggregate pushdown. The layer also bundles the companion 're2' extension (ClickHouse-compatible RE2 regex functions) used for regex pushdown. Extracted from ClickHouse's official prebuilt image (like pg_duckdb). PG17/PG18 only -- upstream ships no PG19 image."

--- a/extensions/pg_clickhouse/test.sql
+++ b/extensions/pg_clickhouse/test.sql
@@ -2,8 +2,10 @@
 --
 -- pg_clickhouse is a Foreign Data Wrapper: real queries require a running
 -- ClickHouse server, which isn't available in CI. These checks validate that
--- the extension (and its bundled re2 companion) load and that their SQL objects
--- work without a live ClickHouse backend.
+-- the extension loads, its FDW objects work, and its re2 regex-pushdown wiring
+-- is correct -- all without a live ClickHouse backend (EXPLAIN without ANALYZE
+-- never contacts the remote). The re2 functions themselves are covered by
+-- extensions/pg_re2/test.sql.
 
 -- 1. Load / sanity: the clickhouse_fdw foreign data wrapper is registered.
 --    (Doubles as the smoke test.)
@@ -35,23 +37,48 @@ END;
 
 DROP SERVER IF EXISTS pgclickhouse_test_srv CASCADE;
 
--- 3. Bundled companion: the re2 extension (ClickHouse-compatible RE2 regex,
---    used for regex pushdown) loads and matches correctly.
+-- 3. re2 regex pushdown wiring (the reason pg_clickhouse DEPENDS on re2).
+--    pg_clickhouse's deparser must recognize functions/operators owned by the
+--    're2' extension and translate them into ClickHouse's regex functions.
+--    We assert that a re2 match (the '@~' operator) is pushed down as
+--    ClickHouse `match(...)` in the generated Remote SQL. EXPLAIN (no ANALYZE)
+--    builds the remote query WITHOUT contacting ClickHouse, so this is safe in
+--    CI. This check proves the re2 companion is correctly connected; if re2
+--    were absent, the '@~' operator wouldn't exist and pushdown wouldn't occur.
 CREATE EXTENSION IF NOT EXISTS re2;
 
+CREATE SERVER pgclickhouse_re2_srv
+    FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (host 'localhost', port '9000');
+CREATE USER MAPPING FOR CURRENT_USER
+    SERVER pgclickhouse_re2_srv OPTIONS (user 'default', password '');
+CREATE FOREIGN TABLE pgclickhouse_re2_ft (a text)
+    SERVER pgclickhouse_re2_srv OPTIONS (table_name 'dummy');
+
+CREATE OR REPLACE FUNCTION pg_temp.pgch_re2_pushdown() RETURNS boolean AS $$
+DECLARE
+    ln    text;
+    found boolean := false;
+BEGIN
+    FOR ln IN
+        EXECUTE $q$EXPLAIN (VERBOSE)
+                   SELECT a FROM pgclickhouse_re2_ft WHERE a @~ 'foo.*bar'$q$
+    LOOP
+        IF ln LIKE '%match(a,%' THEN
+            found := true;
+        END IF;
+    END LOOP;
+    RETURN found;
+END;
+$$ LANGUAGE plpgsql;
+
 SELECT CASE
-    WHEN re2match('hello world', 'w.rld') IS TRUE
-     AND re2match('hello world', '^x') IS FALSE
-    THEN 'PASS pg_clickhouse: re2match regex evaluation works'
-    ELSE 'FAIL pg_clickhouse: re2match regex evaluation broken'
+    WHEN pg_temp.pgch_re2_pushdown()
+    THEN 'PASS pg_clickhouse: re2 regex pushed down to ClickHouse match() (re2 wired)'
+    ELSE 'FAIL pg_clickhouse: re2 regex NOT pushed down (re2 not connected)'
 END;
 
--- 4. re2 extraction returns the captured group.
-SELECT CASE
-    WHEN re2extract('2024-08-12', '([0-9]{4})') = '2024'
-     AND re2countmatches('a1b2c3', '[0-9]') = 3
-    THEN 'PASS pg_clickhouse: re2extract/re2countmatches work'
-    ELSE 'FAIL pg_clickhouse: re2extract/re2countmatches broken'
-END;
+DROP FOREIGN TABLE IF EXISTS pgclickhouse_re2_ft;
+DROP SERVER IF EXISTS pgclickhouse_re2_srv CASCADE;
 
-DROP EXTENSION IF EXISTS re2;
+

--- a/extensions/pg_clickhouse/test.sql
+++ b/extensions/pg_clickhouse/test.sql
@@ -1,0 +1,57 @@
+-- pg_clickhouse integration tests
+--
+-- pg_clickhouse is a Foreign Data Wrapper: real queries require a running
+-- ClickHouse server, which isn't available in CI. These checks validate that
+-- the extension (and its bundled re2 companion) load and that their SQL objects
+-- work without a live ClickHouse backend.
+
+-- 1. Load / sanity: the clickhouse_fdw foreign data wrapper is registered.
+--    (Doubles as the smoke test.)
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1 FROM pg_foreign_data_wrapper WHERE fdwname = 'clickhouse_fdw'
+    )
+    THEN 'PASS pg_clickhouse: clickhouse_fdw foreign data wrapper registered'
+    ELSE 'FAIL pg_clickhouse: clickhouse_fdw foreign data wrapper missing'
+END;
+
+-- 2. FDW handler/validator work: creating a foreign server + user mapping
+--    exercises the FDW's validator without contacting ClickHouse.
+DO $$
+BEGIN
+    CREATE SERVER pgclickhouse_test_srv
+        FOREIGN DATA WRAPPER clickhouse_fdw
+        OPTIONS (host 'localhost', port '8123');
+    CREATE USER MAPPING FOR CURRENT_USER
+        SERVER pgclickhouse_test_srv
+        OPTIONS (user 'default', password '');
+END $$;
+
+SELECT CASE
+    WHEN EXISTS (SELECT 1 FROM pg_foreign_server WHERE srvname = 'pgclickhouse_test_srv')
+    THEN 'PASS pg_clickhouse: CREATE SERVER via clickhouse_fdw succeeded'
+    ELSE 'FAIL pg_clickhouse: CREATE SERVER via clickhouse_fdw failed'
+END;
+
+DROP SERVER IF EXISTS pgclickhouse_test_srv CASCADE;
+
+-- 3. Bundled companion: the re2 extension (ClickHouse-compatible RE2 regex,
+--    used for regex pushdown) loads and matches correctly.
+CREATE EXTENSION IF NOT EXISTS re2;
+
+SELECT CASE
+    WHEN re2match('hello world', 'w.rld') IS TRUE
+     AND re2match('hello world', '^x') IS FALSE
+    THEN 'PASS pg_clickhouse: re2match regex evaluation works'
+    ELSE 'FAIL pg_clickhouse: re2match regex evaluation broken'
+END;
+
+-- 4. re2 extraction returns the captured group.
+SELECT CASE
+    WHEN re2extract('2024-08-12', '([0-9]{4})') = '2024'
+     AND re2countmatches('a1b2c3', '[0-9]') = 3
+    THEN 'PASS pg_clickhouse: re2extract/re2countmatches work'
+    ELSE 'FAIL pg_clickhouse: re2extract/re2countmatches broken'
+END;
+
+DROP EXTENSION IF EXISTS re2;

--- a/extensions/pg_re2/Dockerfile
+++ b/extensions/pg_re2/Dockerfile
@@ -2,61 +2,42 @@
 ARG PG_MAJOR=17
 ARG PG_TAG=${PG_MAJOR}
 ARG LAYOUT=classic
-ARG EXT_VERSION=0.10.0
 
-# Use ClickHouse's official pre-built pg_clickhouse image (avoids compiling the
-# extension + the RE2/abseil dependency stack). Same approach as pg_duckdb.
-# NOTE: upstream tags the image WITHOUT a leading "v" (e.g. 18-0.10.0), so
-# EXT_VERSION/VERSION_XX are stored v-less to match this tag directly.
-FROM ghcr.io/clickhouse/pg_clickhouse:${PG_MAJOR}-${EXT_VERSION} AS upstream
-
-# Snapshot base image libraries for diffing (by soname, not canonical path)
 FROM postgres:${PG_TAG} AS base
 RUN find /usr/lib -name '*.so*' \( -type f -o -type l \) 2>/dev/null \
     | sed 's|.*/||' | sort -u > /tmp/base-libs.txt
 
-# Collector: extract extension + bundle missing runtime deps.
-# The upstream image ships two extensions (pg_clickhouse + re2). We extract ONLY
-# pg_clickhouse here; the recommended re2 companion (ClickHouse-compatible RE2
-# regex, used for regex pushdown) is shipped as its own pglayers layer
-# (extensions/pg_re2, built from source) and wired up via DEPENDS="re2". Two
-# layers must never both ship re2 (they would collide at re2.so/re2.control on
-# the PG17 classic layout).
-FROM upstream AS collector
+FROM postgres:${PG_TAG} AS builder
 ARG PG_MAJOR
-COPY --from=base /tmp/base-libs.txt /tmp/base-libs.txt
+ARG EXT_VERSION=v0.4.1
 
-USER root
-
+# pg_re2 is a PGXS C++17 extension that links RE2 (-lre2 -lstdc++) and uses
+# PostgreSQL's ICU headers (libicu-dev). libre2-dev pulls in the abseil stack.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends patchelf
+    apt-get update && apt-get install -y --no-install-recommends \
+    build-essential git ca-certificates patchelf \
+    postgresql-server-dev-${PG_MAJOR} \
+    libre2-dev libicu-dev
 
-# Copy pg_clickhouse extension artifacts to /output (re2 is shipped separately)
+RUN git clone --branch ${EXT_VERSION} --depth 1 \
+    https://github.com/ClickHouse/pg_re2.git /tmp/ext
+
+WORKDIR /tmp/ext
+
+RUN make -j"$(nproc)" && make install DESTDIR=/output \
+    && find /output -name '*.so' -exec strip --strip-unneeded {} \;
+
+# Bundle ALL runtime shared libraries not in the base postgres image so the
+# layer is fully self-contained (re2 links libre2.so.11, which pulls in the
+# whole libabsl_* stack -- none of which is in the base image). libstdc++ is
+# already in the base image, so it is not bundled. Collisions in the flat
+# classic layout are prevented later by relocating these into a private dir
+# with RUNPATH + mangled sonames.
+COPY --from=base /tmp/base-libs.txt /tmp/base-libs.txt
 RUN set -eux; \
     PG=${PG_MAJOR}; \
-    LIB="/usr/lib/postgresql/${PG}/lib"; \
-    SHARE="/usr/share/postgresql/${PG}/extension"; \
-    mkdir -p "/output${LIB}/bitcode" \
-             "/output${SHARE}"; \
-    cp "${LIB}/pg_clickhouse.so" "/output${LIB}/"; \
-    cp "${SHARE}"/pg_clickhouse* "/output${SHARE}/"; \
-    # Bitcode: pg_clickhouse index file + subtree. Copy only our files so we
-    # never overwrite the base image's bitcode entries.
-    [ -f "${LIB}/bitcode/pg_clickhouse.index.bc" ] && \
-        cp "${LIB}/bitcode/pg_clickhouse.index.bc" "/output${LIB}/bitcode/" || true; \
-    [ -d "${LIB}/bitcode/pg_clickhouse" ] && \
-        cp -r "${LIB}/bitcode/pg_clickhouse" "/output${LIB}/bitcode/" || true
-
-# Bundle ALL runtime shared libraries that pg_clickhouse needs but the base
-# postgres image doesn't have (libcurl + transitive brotli/nghttp/ssh2/rtmp/psl),
-# so the layer is fully self-contained (never rely on a sibling layer to provide
-# libcurl et al.). Compare by soname to avoid bundling older versions of libs
-# already in the base image. Collisions in the flat classic layout are prevented
-# later by relocating these into a private dir with RUNPATH + mangled sonames.
-RUN set -eux; \
-    PG=${PG_MAJOR}; \
-    ldd /usr/lib/postgresql/${PG}/lib/pg_clickhouse.so 2>/dev/null \
+    find /output/usr/lib/postgresql/${PG}/lib -name '*.so' -exec ldd {} + 2>/dev/null \
         | awk '/=>/ && /\// {print $3}' | sort -u > /tmp/all-deps.txt; \
     while IFS= read -r lib; do \
         soname="$(basename "$lib")"; \
@@ -65,19 +46,19 @@ RUN set -eux; \
         fi; \
         dest="$(echo "$lib" | sed 's|^/lib/|/usr/lib/|')"; \
         mkdir -p "/output$(dirname "$dest")"; \
-        cp -aL "$lib" "/output${dest}" 2>/dev/null || true; \
+        cp -aL "$lib" "/output$dest" 2>/dev/null || true; \
     done < /tmp/all-deps.txt; \
     find /output -name '*.so*' -type f -exec strip --strip-unneeded {} \; 2>/dev/null || true
 
 # --- Layout selection ---
 # Classic (PG 17): relocate bundled deps into an extension-private directory
-# and point each ELF object's RUNPATH at it via $ORIGIN. Keeps the flat layout
+# and point the extension's RUNPATH at it via $ORIGIN. Keeps the flat layout
 # self-contained AND collision-free (private dir name is unique per ext).
-FROM collector AS classic-relocate
+FROM builder AS classic-relocate
 ARG PG_MAJOR
 RUN set -eux; \
     PG=${PG_MAJOR}; \
-    EXT=pg_clickhouse; \
+    EXT=pg_re2; \
     LIBDIR="/output/usr/lib/postgresql/${PG}/lib"; \
     DEPS_DIR="${LIBDIR}/${EXT}-deps"; \
     tag="pglx_${EXT}_"; \
@@ -85,11 +66,9 @@ RUN set -eux; \
     find /output/usr/lib -path '/output/usr/lib/postgresql' -prune -o \
         -name '*.so*' \( -type f -o -type l \) -print \
         | while IFS= read -r lib; do mv "$lib" "$DEPS_DIR/"; done; \
-    # Mangle each bundled dep's soname with a per-extension prefix. sonames are
-    # process-global, so a private dir + RUNPATH alone does NOT isolate symbols:
-    # if a sibling extension loads its own libssh2.so.1 first, our libcurl would
-    # bind to it and hit undefined symbols. Unique sonames make cross-layer
-    # clashes impossible while keeping the layer self-contained.
+    # Mangle bundled dep sonames with a per-extension prefix so they can never
+    # satisfy another layer's soname in the shared postgres process. See
+    # extensions/pg_duckdb/Dockerfile for the rationale.
     find "$DEPS_DIR" -type l -delete 2>/dev/null || true; \
     for dep in "$DEPS_DIR"/*.so*; do \
         [ -f "$dep" ] || continue; \
@@ -98,7 +77,6 @@ RUN set -eux; \
         patchelf --set-soname "${tag}${soname}" "$dep"; \
         mv "$dep" "$DEPS_DIR/${tag}${soname}"; \
     done; \
-    # Rewrite NEEDED refs to bundled libs across every ELF object we ship.
     for obj in "$LIBDIR"/*.so* "$DEPS_DIR"/*.so*; do \
         [ -f "$obj" ] || continue; \
         for need in $(patchelf --print-needed "$obj" 2>/dev/null); do \
@@ -108,7 +86,6 @@ RUN set -eux; \
             fi; \
         done; \
     done; \
-    # Point RUNPATHs at the private dir ($ORIGIN for siblings + deps).
     for so in "$LIBDIR"/*.so*; do \
         [ -f "$so" ] || continue; \
         patchelf --set-rpath "\$ORIGIN:\$ORIGIN/${EXT}-deps" "$so"; \
@@ -126,13 +103,12 @@ COPY --from=classic-relocate /output/ /
 # Each extension resolves its OWN bundled deps from its private
 # /extensions/<ext>/lib via $ORIGIN RUNPATH -- never through a global ld.so
 # cache. Bundled-dep sonames are mangled with a per-extension prefix so two
-# layers that ship the same soname (e.g. libssh2.so.1 pulled in via libcurl by
-# both postgis and pg_clickhouse) can't clash in the shared postgres process.
-FROM collector AS normalizer
+# layers that ship the same soname can't clash in the shared postgres process.
+FROM builder AS normalizer
 ARG PG_MAJOR
 RUN set -eux; \
     PG=${PG_MAJOR}; \
-    tag="pglx_pg_clickhouse_"; \
+    tag="pglx_pg_re2_"; \
     mkdir -p /isolated/lib /isolated/share/extension; \
     find /output/usr/lib/postgresql/${PG}/lib -maxdepth 1 -type f \
         -exec cp -a {} /isolated/lib/ \; ; \

--- a/extensions/pg_re2/extension.conf
+++ b/extensions/pg_re2/extension.conf
@@ -1,0 +1,7 @@
+DESCRIPTION="ClickHouse-compatible regex functions using RE2"
+REPO="https://github.com/ClickHouse/pg_re2.git"
+LICENSE="PostgreSQL"
+VERSION_17="v0.4.1"
+VERSION_18="v0.4.1"
+VERSION_19="v0.4.1"
+NOTES="Built from source (PGXS, links libre2 + abseil). Standalone RE2 regex extension; also the recommended companion for pg_clickhouse regex pushdown."

--- a/extensions/pg_re2/test.sql
+++ b/extensions/pg_re2/test.sql
@@ -1,0 +1,35 @@
+-- re2 (pg_re2) integration tests
+-- ClickHouse-compatible regex functions backed by Google RE2.
+
+-- 1. Load / sanity: the extension's core matcher works (smoke test).
+SELECT CASE
+    WHEN re2match('hello world', 'h.*o') IS TRUE
+     AND re2match('hello world', '^xyz') IS FALSE
+    THEN 'PASS re2: re2match regex evaluation works'
+    ELSE 'FAIL re2: re2match regex evaluation broken'
+END;
+
+-- 2. Extraction returns the first captured group.
+SELECT CASE
+    WHEN re2extract('2024-08-12', '([0-9]{4})') = '2024'
+    THEN 'PASS re2: re2extract captures group'
+    ELSE 'FAIL re2: re2extract broken'
+END;
+
+-- 3. Match counting.
+SELECT CASE
+    WHEN re2countmatches('a1b2c3', '[0-9]') = 3
+     AND re2countmatches('no digits here', '[0-9]') = 0
+    THEN 'PASS re2: re2countmatches works'
+    ELSE 'FAIL re2: re2countmatches broken'
+END;
+
+-- 4. Works over a table column (integration with normal SQL evaluation).
+CREATE TEMP TABLE re2_test_urls(u text);
+INSERT INTO re2_test_urls VALUES ('http://a.com'), ('https://b.org'), ('ftp://c.net');
+SELECT CASE
+    WHEN (SELECT count(*) FROM re2_test_urls WHERE re2match(u, '^https?://')) = 2
+    THEN 'PASS re2: re2match filters table rows correctly'
+    ELSE 'FAIL re2: re2match table filtering broken'
+END;
+DROP TABLE re2_test_urls;

--- a/profiles/full.txt
+++ b/profiles/full.txt
@@ -43,6 +43,7 @@ pgpcre
 pg_permissions
 pg_pwhash
 pg_qualstats
+pg_re2
 pg_repack
 pg_roaringbitmap
 pgrouting

--- a/profiles/full.txt
+++ b/profiles/full.txt
@@ -19,6 +19,7 @@ periods
 pgaudit
 pg_background
 pg_bigm
+pg_clickhouse
 pg_cron
 pg_csv
 pg_dirtyread

--- a/tests/test-layers.sh
+++ b/tests/test-layers.sh
@@ -481,6 +481,7 @@ declare -A EXT_SQL_NAMES=(
     [pg_net]="pg_net"
     [pg_partman]="pg_partman"
     [pg_qualstats]="pg_qualstats"
+    [pg_re2]="re2"
     [pg_repack]="pg_repack"
     [pg_roaringbitmap]="roaringbitmap"
     [pg_similarity]="pg_similarity"

--- a/tests/test-layers.sh
+++ b/tests/test-layers.sh
@@ -468,6 +468,7 @@ declare -A EXT_SQL_NAMES=(
     [jsquery]="jsquery"
     [orafce]="orafce"
     [pg_bigm]="pg_bigm"
+    [pg_clickhouse]="pg_clickhouse"
     [pg_cron]="pg_cron"
     [pg_duckdb]="pg_duckdb"
     [pg_durable]="pg_durable"


### PR DESCRIPTION
## Summary

Adds two related extensions:

- **`pg_clickhouse`** (`ClickHouse/pg_clickhouse`) — Foreign Data Wrapper to query ClickHouse from PostgreSQL, with WHERE/JOIN/aggregate pushdown. **Not on PGDG apt**, so it is extracted from ClickHouse's official prebuilt image (`ghcr.io/clickhouse/pg_clickhouse:<pg>-<ver>`), the same "reuse upstream binary assets" pattern already used by `pg_duckdb`. **PG 17/18** (upstream publishes images for PG 13–18 only; no PG 19 image).
- **`pg_re2`** (`ClickHouse/pg_re2`) — standalone `re2` extension (ClickHouse-compatible regex via Google RE2). **Not on PGDG apt**, so it is **built from source** (PGXS, C++17, links prebuilt `libre2` + abseil). **PG 17/18/19**.

`pg_clickhouse` uses `re2` for **regex pushdown**, wired via `DEPENDS="re2"`.

## Why re2 is a separate layer (not bundled)

The upstream `pg_clickhouse` image ships both `pg_clickhouse` and `re2`. Bundling both in one pglayers layer collides on the **PG17 classic layout** (two layers shipping `re2.so`/`re2.control`; the collision check runs across all extensions, before `CONFLICTS` filtering). So `re2` is shipped as its own source-built layer and `pg_clickhouse` declares `DEPENDS="re2"`. Bonus: the `pg_clickhouse` layer shrinks (the abseil/libre2 stack lives in `pg_re2`).

## Build/version notes

- `pg_clickhouse`: upstream tags releases `vX.Y.Z` but tags the **image** `X.Y.Z` (no `v`). `VERSION_XX` is stored v-less to match the image tag; `monitor-extensions.yml` now preserves each conf's existing tag-prefix convention on bumps.
- `pg_re2`: standard `vX.Y.Z` tags → auto-monitored, no special handling.
- Compile cost for `pg_re2` is trivial (~1.3s; it links a prebuilt `libre2`); cold build time is dominated by apt-installing the toolchain (~26s), fully cached in CI.

## Testing

Validated locally on **PG17 (classic)** and **PG18 (isolated)**, plus **PG19** for `pg_re2`:

- Both build; self-contained (`ldd` clean via `$ORIGIN` RUNPATH + mangled sonames).
- Combined image (both layers) builds **collision-free** on PG17 and PG18.
- `CREATE EXTENSION` succeeds for both; all `test.sql` checks pass.
- **re2↔pg_clickhouse wiring** is asserted offline: `EXPLAIN (VERBOSE)` on a foreign-table query using re2's `@~` operator deparses to ClickHouse `match(...)` in the Remote SQL (no live ClickHouse needed).
- `make check-profiles`, `make check-licenses` (Apache-2.0 / PostgreSQL), `make list`, `shellcheck` all clean.

## Docs / registration

- `README.md` extensions table (both rows).
- `profiles/full.txt` (both, in sort order).
- `tests/test-layers.sh` `EXT_SQL_NAMES` (`[pg_clickhouse]="pg_clickhouse"`, `[pg_re2]="re2"` — the latter is load-bearing for `DEPENDS` resolution in `check-profiles`).

## Follow-up (not in this PR)

Auto-resolving `DEPENDS` transitively at combined-image build time (so a `pg_clickhouse`-only profile pulls in `pg_re2` automatically). Today `DEPENDS` is enforced at profile-authoring time by `make check-profiles`.