### PR TITLE
chore: bump PG 19 base image to 19beta3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ add-apt-ext: ## Scaffold a new APT extension (PKG=<apt package> [NAME=<dir>] [PG
 	@test -n "$(PKG)" || { echo "Usage: make add-apt-ext PKG=<apt package> [NAME=<dir>] [PG=17]"; exit 1; }
 	@name="$(or $(NAME),$(subst -,_,$(PKG)))"; \
 	pg="$(or $(PG),17)"; \
-	pgtag="$$pg"; [ "$$pg" = "19" ] && pgtag="19beta2"; \
+	pgtag="$$pg"; [ "$$pg" = "19" ] && pgtag="19beta3"; \
 	dir="extensions/$$name"; \
 	if [ -e "$$dir" ]; then echo "Error: $$dir already exists"; exit 1; fi; \
 	echo "Probing PGDG for postgresql-$$pg-$(PKG)..."; \

--- a/README.md
+++ b/README.md
@@ -687,8 +687,8 @@ make build EXT=pgvector PG=17
 make build-all PG=17
 
 # Build for PG 19 (beta -- requires PG_TAG override until GA)
-make build EXT=pgvector PG=19 PG_TAG=19beta2
-make build-all PG=19 PG_TAG=19beta2
+make build EXT=pgvector PG=19 PG_TAG=19beta3
+make build-all PG=19 PG_TAG=19beta3
 
 # Build a combined image with ALL extensions included
 make image PG=17 REGISTRY=local

--- a/scripts/apt-support.sh
+++ b/scripts/apt-support.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 CACHE_DIR="${PGLAYERS_APT_CACHE_DIR:-/tmp/pglayers-apt-cache}"
 
-_pg_tag() { [ "$1" = "19" ] && echo "19beta2" || echo "$1"; }
+_pg_tag() { [ "$1" = "19" ] && echo "19beta3" || echo "$1"; }
 
 # Debian apt version -> clean, docker-tag-safe upstream version.
 # e.g. 0.8.5-1.pgdg13+1 -> 0.8.5 ; 3.6.4+dfsg-2.pgdg13+1 -> 3.6.4

--- a/scripts/detect-license.sh
+++ b/scripts/detect-license.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 pg="${1:?usage: detect-license.sh <pg> <apt_package>}"
 pkg="${2:?usage: detect-license.sh <pg> <apt_package>}"
-tag="$pg"; [ "$pg" = "19" ] && tag="19beta2"
+tag="$pg"; [ "$pg" = "19" ] && tag="19beta3"
 
 # Fetch the whole copyright file once. Distinguish an infrastructure failure
 # (docker/apt error -> fail fast, non-zero) from a package that installs but


### PR DESCRIPTION
## Summary

Bumps the PostgreSQL 19 base image tag from `19beta2` to `19beta3` across the build tooling.

## Changes

- `Makefile` — `add-apt-ext` scaffold PG tag mapping
- `scripts/apt-support.sh` — `_pg_tag()` mapping
- `scripts/detect-license.sh` — license-detection PG tag mapping
- `README.md` — PG 19 build examples

## Notes

PG 19 remains beta, so builds still require the `PG_TAG` override until GA.