### PR TITLE
ci(monitor-base-image): fix failure guard and track PG 19 beta tag

### DIFF
--- a/.github/workflows/monitor-base-image.yml
+++ b/.github/workflows/monitor-base-image.yml
@@ -46,27 +46,44 @@ jobs:
           fi
 
           for pg in 17 18 19; do
-            # Get current manifest digest from Docker Hub
-            current=$(docker buildx imagetools inspect \
-              --raw "docker.io/library/postgres:${pg}" 2>/dev/null \
-              | sha256sum | awk '{print "sha256:"$1}')
+            # Map the PG major to the actual published Docker tag. PG 19 has no
+            # GA tag yet, so the build (Makefile, scripts/detect-license.sh) uses
+            # postgres:19beta3 -- track the same tag so beta rebuilds are caught.
+            # Remove this mapping once postgres:19 goes GA.
+            tag="$pg"
+            [ "$pg" = "19" ] && tag="19beta3"
+            image="docker.io/library/postgres:${tag}"
 
-            if [ -z "$current" ] || [ "$current" = "sha256:" ]; then
-              echo "::warning::Failed to fetch digest for postgres:${pg}"
+            # Fetch the raw manifest to a file and check the inspect exit status
+            # DIRECTLY. Do NOT pipe the command into sha256sum: on failure the
+            # inspect prints nothing and "'' | sha256sum" still yields the sha256
+            # of empty input (e3b0c442...b855) -- a bogus "digest" that passes the
+            # old non-empty guard, silently overwrites a good value, and fires a
+            # spurious PR + full rebuild. On any failure/empty output, skip this
+            # PG and leave the stored digest untouched.
+            manifest="$(mktemp)"
+            if ! docker buildx imagetools inspect --raw "$image" >"$manifest" 2>/dev/null \
+               || [ ! -s "$manifest" ]; then
+              echo "::warning::Failed to fetch manifest for ${image}; leaving stored digest untouched"
+              rm -f "$manifest"
               continue
             fi
+            # Hash the exact manifest bytes (sha256sum < file == the old
+            # "docker ... | sha256sum"), so 17/18 baselines are unchanged.
+            current="sha256:$(sha256sum <"$manifest" | awk '{print $1}')"
+            rm -f "$manifest"
 
-            # Get stored digest
+            # Stored digest is keyed by PG major, independent of the tag.
             stored=$(jq -r ".\"postgres:${pg}\" // \"\"" "$DIGEST_FILE")
 
             if [ "$current" != "$stored" ]; then
-              echo "postgres:${pg} changed: ${stored:-<new>} -> ${current}"
+              echo "postgres:${pg} (${tag}) changed: ${stored:-<new>} -> ${current}"
               CHANGED_VERSIONS="${CHANGED_VERSIONS:+${CHANGED_VERSIONS} }${pg}"
               # Update the file
               jq --arg key "postgres:${pg}" --arg val "$current" \
                 '.[$key] = $val' "$DIGEST_FILE" > tmp.json && mv tmp.json "$DIGEST_FILE"
             else
-              echo "postgres:${pg} unchanged: ${current}"
+              echo "postgres:${pg} (${tag}) unchanged: ${current}"
             fi
           done
 


### PR DESCRIPTION
## Problem

Follow-up to #62. The digest check had two bugs around PG 19:

The loop inspected the fixed tag **`postgres:19`**, which doesn't exist on Docker Hub yet (PG 19 is beta — only `postgres:19beta3` is published). This exposed:

1. **Broken failure guard.** On a failed/absent `imagetools inspect`, stderr was swallowed by `2>/dev/null` and the empty stdout was piped into `sha256sum`, producing the sha256 of *empty input* (`sha256:e3b0c442...b855`). The guard (`-z` / `== "sha256:"`) never caught it, so the failure was stored as if it were a real digest. That's why the tracked `postgres:19` value is currently that empty-hash. Worse: a **transient Docker Hub hiccup on 17/18** would overwrite a good digest with the empty-hash → spurious PR + full rebuild.

2. **PG 19 tracked the wrong tag** — so `19beta3` rebuilds (what `main` actually builds on) were invisible.

## Fix

- **Check the `inspect` exit status directly** (write the manifest to a temp file; skip the PG on failure/empty output, leaving the stored digest untouched). No more empty-hash artifact.
- **Map PG 19 → `19beta3`**, matching the build (`Makefile:204`, `scripts/detect-license.sh:15`). Digests stay keyed by PG *major*. A `# Remove when 19 goes GA` note is included.

## Answering the original question

- ✅ Now catches `postgres:19beta3` updates (and will catch `postgres:19` GA once the mapping is dropped).
- ✅ First run after merge records the real `19beta3` digest (replacing the empty-hash), and 17/18 are unaffected — hashing is byte-identical to the old piped method (`sha256sum < file`), verified locally.

## Note

Like #62, this only touches `.github/workflows/monitor-base-image.yml` (not in `ci.yml`'s path filters), so `Test PG 17` won't run here — needs an admin merge.