### PR TITLE
docs(agents): document PG base-image tag mapping to prevent PG19 drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,58 @@ published:
 Do not pin to old versions unless the latest has a known incompatibility
 or license change. Stale versions are a bug.
 
+### PostgreSQL base image tags (pre-release majors)
+
+Supported PG majors are **17, 18, 19**. The Docker tag for a GA major is
+just the major (`postgres:17`), but a **pre-release major has no bare tag** --
+Docker Hub publishes only pre-release tags (`postgres:19beta3`, later
+`19beta4`, `19rc1`, and finally the GA `postgres:19`). So the build maps each
+PG major to the **actual published Docker tag**. Today that mapping is:
+
+```
+19 -> 19beta3     # 17, 18 map to themselves
+```
+
+**This mapping is duplicated in several files and they MUST stay in
+lockstep.** A mismatch is the "PG 19 drift" bug: e.g. the base-image monitor
+tracks the `19beta3` digest while `ci.yml` builds on `19beta2`, so PG 19 looks
+*perpetually changed*, the monitor opens endless PRs, and the shipped images
+never match the tracked base. Every place that hardcodes the pre-release tag:
+
+1. `Makefile` -- the `add-apt-ext` scaffold
+   (`pgtag="$pg"; [ "$pg" = "19" ] && pgtag="19beta3"`).
+2. `scripts/apt-support.sh` -- `_pg_tag()`.
+3. `scripts/detect-license.sh` -- the `tag=` line.
+4. `.github/workflows/ci.yml` -- **every** occurrence: the
+   `${{ matrix.pg == '19' && '19beta3' || matrix.pg }}` build-args / `PG_TAG`
+   envs, the `docker pull postgres:19beta3` + `docker tag ... postgres:19`
+   lines, and the `profile-images` `PG_TAG=...`.
+5. `.github/workflows/monitor-base-image.yml` -- the check-step
+   `[ "$pg" = "19" ] && tag="19beta3"`.
+
+**When the pre-release tag rolls** (`19beta3` -> `19beta4` -> `19rc1`):
+
+1. Update the tag in **all five** locations above (one find-and-replace of the
+   old tag string -- it only ever appears as this tag).
+2. Verify no drift remains -- there must be exactly one tag string across the
+   repo:
+   ```bash
+   grep -rn '19beta\|19rc' Makefile scripts/ .github/ \
+     | grep -v base-image-digests.json
+   ```
+   Every hit must show the **same** new tag.
+3. `make test REGISTRY=local PG=19` (the base monitor will record the new
+   digest on its next run).
+
+**When the major goes GA** (`postgres:19` is published): **remove** the mapping
+entirely from all five files so PG 19 maps to itself (`19`), then run the grep
+above to confirm no `19beta`/`19rc` remains, and `make test ... PG=19`.
+
+> The mapping's duplication is exactly what caused the drift. If you touch this
+> more than once, prefer centralizing it into a single helper
+> (e.g. `scripts/pg-tag.sh <major>` echoing the tag) that the Makefile,
+> scripts, and both workflows call, so there is one source of truth.
+
 ## Testing Requirements
 
 When adding new extensions or modifying existing ones, **always run the


### PR DESCRIPTION
Adds a **PostgreSQL base image tags (pre-release majors)** subsection to AGENTS.md's Version Policy.

## Why

The `19beta2`/`19beta3` split fixed in #65 was a *documentation* gap: the PG-major → Docker-tag mapping (`19 → 19beta3`) is hardcoded in **5 files** with nothing telling a contributor they must all move together. This documents:

- Why pre-GA majors need a tag mapping (no bare `postgres:19` tag exists yet).
- **Every** location that hardcodes the tag (`Makefile`, `scripts/apt-support.sh`, `scripts/detect-license.sh`, `.github/workflows/ci.yml`, `.github/workflows/monitor-base-image.yml`).
- A checklist for rolling the pre-release tag (`beta3 → beta4 → rc1`) and for **dropping** the mapping at GA.
- A `grep` to verify no drift remains.
- A recommendation to centralize into a single `scripts/pg-tag.sh` helper.

## Note

Docs-only, not in `ci.yml`'s path filters, so `Test PG 17` won't run — needs an admin merge (same as other docs/workflow-only changes).