### PR TITLE
ci: centralize PG base tag (pg-tag.sh) + drive base rebuild via the digest PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
       extensions: ${{ steps.set.outputs.extensions }} # promote/manifest matrix
       publish: ${{ steps.set.outputs.publish }}        # 'true' on push/schedule/dispatch
       test_pgs: ${{ steps.set.outputs.test_pgs }}      # PG majors the test jobs cover
+      pg_tags: ${{ steps.set.outputs.pg_tags }}        # PG major -> base-image docker tag (pg-tag.sh)
     steps:
       - uses: actions/checkout@v7
         with:
@@ -137,11 +138,14 @@ jobs:
             schedule) build_all=true ;;
             workflow_dispatch) [ -z "$ext_filter" ] && build_all=true ;;
           esac
-          # A change to the build/compose plumbing can affect every layer, so a
-          # PR (or merge) that touches it exercises a full rebuild.
+          # A change to the build/compose plumbing -- or to the tracked base
+          # image digests -- can affect every layer, so a PR (or merge) that
+          # touches it exercises a full rebuild. base-image-digests.json is the
+          # base-image monitor's signal: its digest PR builds+tests all layers
+          # on the fresh base, and the merge promotes them (no separate dispatch).
           if { [ "$event" = "push" ] || [ "$event" = "pull_request" ]; } && \
              git diff --name-only HEAD~1 \
-               | grep -qE '^(\.github/workflows/ci\.yml|Makefile|scripts/)'; then
+               | grep -qE '^(\.github/workflows/ci\.yml|\.github/base-image-digests\.json|Makefile|scripts/)'; then
             build_all=true
           fi
 
@@ -214,6 +218,16 @@ jobs:
           publish='false'
           case "$event" in push|schedule|workflow_dispatch) publish='true' ;; esac
 
+          # PG major -> base-image Docker tag, from the single source of truth
+          # (scripts/pg-tag.sh). Downstream build/test/profile jobs read this map
+          # (needs.matrix.outputs.pg_tags) instead of hardcoding the beta tag.
+          pg_tags='{}'
+          for pg in 17 18 19; do
+            pg_tags=$(echo "$pg_tags" | jq -c \
+              --arg pg "$pg" --arg tag "$(./scripts/pg-tag.sh "$pg")" \
+              '. + {($pg): $tag}')
+          done
+
           # What the test jobs treat as "changed" (pull freshly-built staging /
           # build-from-source fallback) vs "unchanged" (pull published). Mirrors
           # the build scope so a full/targeted rebuild is verified against the
@@ -233,6 +247,7 @@ jobs:
             echo "extensions=$extensions"
             echo "publish=$publish"
             echo "test_pgs=$test_pgs"
+            echo "pg_tags=$pg_tags"
           } >> "$GITHUB_OUTPUT"
           echo "changed: [$changed_out]"
           echo "publish: $publish | test_pgs: $test_pgs"
@@ -314,7 +329,7 @@ jobs:
           ./scripts/ci-retry.sh docker buildx build \
             --platform linux/${{ matrix.arch }} \
             --build-arg PG_MAJOR=${{ matrix.pg }} \
-            --build-arg PG_TAG=${{ matrix.pg == '19' && '19beta3' || matrix.pg }} \
+            --build-arg PG_TAG=${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }} \
             --build-arg EXT_VERSION=${{ matrix.version }} \
             --build-arg EXT_NAME=${{ matrix.extension }} \
             --build-arg LAYOUT=${{ matrix.pg >= 18 && 'isolated' || 'classic' }} \
@@ -367,7 +382,7 @@ jobs:
           ./scripts/ci-retry.sh docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --build-arg PG_MAJOR=${{ matrix.pg }} \
-            --build-arg PG_TAG=${{ matrix.pg == '19' && '19beta3' || matrix.pg }} \
+            --build-arg PG_TAG=${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }} \
             --build-arg EXT_VERSION=${{ matrix.version }} \
             --build-arg APT_PACKAGE=${{ matrix.apt_package }} \
             --build-arg EXT_NAME=${{ matrix.extension }} \
@@ -411,8 +426,8 @@ jobs:
       - name: Tag beta image as major version
         if: matrix.pg == '19'
         run: |
-          docker pull postgres:19beta3
-          docker tag postgres:19beta3 postgres:19
+          docker pull postgres:${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }}
+          docker tag postgres:${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }} postgres:19
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -424,7 +439,7 @@ jobs:
         env:
           SOURCE_REGISTRY: ${{ env.REGISTRY }}/${{ github.repository_owner }}
           PREFIX: ${{ env.PREFIX }}
-          PG_TAG: ${{ matrix.pg == '19' && '19beta3' || matrix.pg }}
+          PG_TAG: ${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }}
           CHANGED: ${{ needs.matrix.outputs.changed }}
           DOCKER_BUILDKIT: '1'
         run: |
@@ -433,7 +448,7 @@ jobs:
           ./scripts/ci-prepare-images.sh ${{ matrix.pg }} $exts
       - name: Run test suite
         env:
-          PG_TAG: ${{ matrix.pg == '19' && '19beta3' || matrix.pg }}
+          PG_TAG: ${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }}
         run: make test REGISTRY=local PG=${{ matrix.pg }} PG_TAG="$PG_TAG"
 
   # ---------------------------------------------------------------------------
@@ -466,8 +481,8 @@ jobs:
       - name: Tag beta image as major version
         if: matrix.pg == '19'
         run: |
-          docker pull postgres:19beta3
-          docker tag postgres:19beta3 postgres:19
+          docker pull postgres:${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }}
+          docker tag postgres:${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }} postgres:19
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -479,7 +494,7 @@ jobs:
         env:
           SOURCE_REGISTRY: ${{ env.REGISTRY }}/${{ github.repository_owner }}
           PREFIX: ${{ env.PREFIX }}
-          PG_TAG: ${{ matrix.pg == '19' && '19beta3' || matrix.pg }}
+          PG_TAG: ${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }}
           CHANGED: ${{ needs.matrix.outputs.changed }}
           DOCKER_BUILDKIT: '1'
         run: |
@@ -622,7 +637,7 @@ jobs:
       - name: Build and push multi-arch profile image
         run: |
           make image PG=${{ matrix.pg }} PROFILE=${{ matrix.profile }} \
-            PG_TAG=${{ matrix.pg == '19' && '19beta3' || matrix.pg }} \
+            PG_TAG=${{ fromJson(needs.matrix.outputs.pg_tags)[matrix.pg] }} \
             REGISTRY=${{ env.REGISTRY }}/${{ github.repository_owner }} \
             IMAGE_TAG=${{ env.REGISTRY }}/${{ github.repository_owner }}/pglayers-${{ matrix.profile }}:${{ matrix.pg }} \
             PLATFORM=linux/amd64,linux/arm64

--- a/.github/workflows/monitor-base-image.yml
+++ b/.github/workflows/monitor-base-image.yml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
     steps:
       # Mint a short-lived GitHub App installation token. Unlike GITHUB_TOKEN,
       # an App token is a distinct identity, so the PR it opens (and the branch
@@ -46,12 +45,11 @@ jobs:
           fi
 
           for pg in 17 18 19; do
-            # Map the PG major to the actual published Docker tag. PG 19 has no
-            # GA tag yet, so the build (Makefile, scripts/detect-license.sh) uses
-            # postgres:19beta3 -- track the same tag so beta rebuilds are caught.
-            # Remove this mapping once postgres:19 goes GA.
-            tag="$pg"
-            [ "$pg" = "19" ] && tag="19beta3"
+            # Map the PG major to the actual published Docker tag via the single
+            # source of truth (scripts/pg-tag.sh); a pre-release major has no bare
+            # tag, so this tracks the same tag the build uses. No mapping lives
+            # here -- edit scripts/pg-tag.sh when the tag rolls / goes GA.
+            tag="$(./scripts/pg-tag.sh "$pg")"
             image="docker.io/library/postgres:${tag}"
 
             # Fetch the raw manifest to a file and check the inspect exit status
@@ -127,23 +125,11 @@ jobs:
               --base main
           fi
 
-          # Enable auto-merge. The App-token push above triggers ci.yml, so the
-          # required "Test PG 17" check runs and the PR merges once it passes.
-          # Falls back gracefully if auto-merge is disabled on the repo.
+          # Enable auto-merge. The App-token push above triggers ci.yml on the
+          # digest PR (base-image-digests.json is a full-rebuild trigger), so the
+          # PR builds+tests every layer on the fresh base; when it auto-merges,
+          # the push promotes them and rebuilds the profile images. There is a
+          # single rebuild path (the merge) -- no separate workflow dispatch, so
+          # nothing races/cancels it. Falls back gracefully if auto-merge is off.
           gh pr merge "$branch" --auto --squash \
             || echo "WARN: could not enable auto-merge (enable it in repo settings)."
-
-      - name: Trigger rebuild for changed versions
-        if: steps.check.outputs.changed != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          changed="${{ steps.check.outputs.changed }}"
-          # If multiple versions changed, rebuild everything
-          if [ "$(echo "$changed" | wc -w)" -gt 1 ]; then
-            echo "Multiple versions changed, triggering full rebuild"
-            gh workflow run ci.yml
-          else
-            echo "Triggering rebuild for PG ${changed}"
-            gh workflow run ci.yml -f pg_version="${changed}"
-          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,45 +81,40 @@ PG major to the **actual published Docker tag**. Today that mapping is:
 19 -> 19beta3     # 17, 18 map to themselves
 ```
 
-**This mapping is duplicated in several files and they MUST stay in
-lockstep.** A mismatch is the "PG 19 drift" bug: e.g. the base-image monitor
-tracks the `19beta3` digest while `ci.yml` builds on `19beta2`, so PG 19 looks
-*perpetually changed*, the monitor opens endless PRs, and the shipped images
-never match the tracked base. Every place that hardcodes the pre-release tag:
+**`scripts/pg-tag.sh` is the single source of truth for this mapping.** It
+takes a PG major and echoes the Docker tag. Everything resolves the tag through
+it, so there is exactly one place to edit:
 
-1. `Makefile` -- the `add-apt-ext` scaffold
-   (`pgtag="$pg"; [ "$pg" = "19" ] && pgtag="19beta3"`).
-2. `scripts/apt-support.sh` -- `_pg_tag()`.
-3. `scripts/detect-license.sh` -- the `tag=` line.
-4. `.github/workflows/ci.yml` -- **every** occurrence: the
-   `${{ matrix.pg == '19' && '19beta3' || matrix.pg }}` build-args / `PG_TAG`
-   envs, the `docker pull postgres:19beta3` + `docker tag ... postgres:19`
-   lines, and the `profile-images` `PG_TAG=...`.
-5. `.github/workflows/monitor-base-image.yml` -- the check-step
-   `[ "$pg" = "19" ] && tag="19beta3"`.
+- `Makefile` -- `PG_TAG ?= $(shell ./scripts/pg-tag.sh $(PG))` (and the
+  `add-apt-ext` scaffold calls it directly).
+- `scripts/apt-support.sh` and `scripts/detect-license.sh` -- call
+  `pg-tag.sh` (via `$(dirname "$0")/pg-tag.sh`).
+- `.github/workflows/ci.yml` -- the `matrix` job builds a `pg_tags`
+  (`{"17":"17","18":"18","19":"19beta3"}`) output from `pg-tag.sh`; every
+  build/test/profile job reads `fromJson(needs.matrix.outputs.pg_tags)[matrix.pg]`.
+- `.github/workflows/monitor-base-image.yml` -- the check step calls `pg-tag.sh`.
+
+Never hardcode `19beta3` (or any pre-release tag) anywhere else. A stray literal
+is the "PG 19 drift" bug: e.g. if `ci.yml` built on `19beta2` while the monitor
+tracked `19beta3`, PG 19 would look *perpetually changed*, the monitor would
+open endless PRs, and the shipped images would never match the tracked base.
 
 **When the pre-release tag rolls** (`19beta3` -> `19beta4` -> `19rc1`):
 
-1. Update the tag in **all five** locations above (one find-and-replace of the
-   old tag string -- it only ever appears as this tag).
-2. Verify no drift remains -- there must be exactly one tag string across the
-   repo:
+1. Edit the single `19)` case line in `scripts/pg-tag.sh`.
+2. Verify no stray literal was reintroduced (the tag must appear only in
+   `pg-tag.sh`):
    ```bash
    grep -rn '19beta\|19rc' Makefile scripts/ .github/ \
-     | grep -v base-image-digests.json
+     | grep -v -e base-image-digests.json -e scripts/pg-tag.sh
    ```
-   Every hit must show the **same** new tag.
-3. `make test REGISTRY=local PG=19` (the base monitor will record the new
-   digest on its next run).
+   This must print nothing.
+3. `make test REGISTRY=local PG=19` (the base monitor records the new digest on
+   its next run).
 
-**When the major goes GA** (`postgres:19` is published): **remove** the mapping
-entirely from all five files so PG 19 maps to itself (`19`), then run the grep
-above to confirm no `19beta`/`19rc` remains, and `make test ... PG=19`.
-
-> The mapping's duplication is exactly what caused the drift. If you touch this
-> more than once, prefer centralizing it into a single helper
-> (e.g. `scripts/pg-tag.sh <major>` echoing the tag) that the Makefile,
-> scripts, and both workflows call, so there is one source of truth.
+**When the major goes GA** (`postgres:19` is published): **delete** the `19)`
+case line in `scripts/pg-tag.sh` so PG 19 maps to itself, then run the grep
+above (it must print nothing) and `make test ... PG=19`.
 
 ## Testing Requirements
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ EXTENSIONS := $(sort $(notdir $(patsubst %/,%,$(wildcard extensions/*/))))
 # Default PG version for single-extension targets
 PG ?= 17
 
+# Base-image Docker tag for $(PG). Resolved via the single source of truth
+# (scripts/pg-tag.sh) so a pre-release major (19 -> 19beta3) is handled in one
+# place. Override explicitly with `make ... PG_TAG=<tag>` if needed.
+PG_TAG ?= $(shell ./scripts/pg-tag.sh $(PG))
+
 # Profile support: override EXTENSIONS with a subset from profiles/<name>.txt
 ifdef PROFILE
   _PROFILE_FILE := profiles/$(PROFILE).txt
@@ -113,7 +118,7 @@ build: _check-ext ## Build a single extension image
 		$(if $(CACHE_REGISTRY),--cache-from type=registry$(comma)ref=$(CACHE_REGISTRY)/$(PREFIX)-$(EXT):$(PG)) \
 		$(if $(CACHE_SCOPE),--cache-to type=gha$(comma)mode=max$(comma)scope=$(EXT)-$(PG)-$(CACHE_ARCH)) \
 		--build-arg PG_MAJOR=$(PG) \
-		--build-arg PG_TAG=$(or $(PG_TAG),$(PG)) \
+		--build-arg PG_TAG=$(PG_TAG) \
 		--build-arg EXT_VERSION=$(EXT_VERSION) \
 		--build-arg APT_PACKAGE=$(EXT_APT_PACKAGE) \
 		--build-arg EXT_NAME=$(EXT) \
@@ -201,7 +206,7 @@ add-apt-ext: ## Scaffold a new APT extension (PKG=<apt package> [NAME=<dir>] [PG
 	@test -n "$(PKG)" || { echo "Usage: make add-apt-ext PKG=<apt package> [NAME=<dir>] [PG=17]"; exit 1; }
 	@name="$(or $(NAME),$(subst -,_,$(PKG)))"; \
 	pg="$(or $(PG),17)"; \
-	pgtag="$$pg"; [ "$$pg" = "19" ] && pgtag="19beta3"; \
+	pgtag="$$(./scripts/pg-tag.sh "$$pg")"; \
 	dir="extensions/$$name"; \
 	if [ -e "$$dir" ]; then echo "Error: $$dir already exists"; exit 1; fi; \
 	echo "Probing PGDG for postgresql-$$pg-$(PKG)..."; \
@@ -274,7 +279,7 @@ image: ## Build a combined image with all extensions
 	total=0; \
 	included_exts=""; \
 	{ \
-		echo "FROM postgres:$(or $(PG_TAG),$(PG))"; \
+		echo "FROM postgres:$(PG_TAG)"; \
 		for ext in $(EXTENSIONS); do \
 			ver=$$(./scripts/ext-version.sh "$$ext" "$(PG)"); \
 			[ -z "$$ver" ] && continue; \

--- a/scripts/apt-support.sh
+++ b/scripts/apt-support.sh
@@ -21,7 +21,9 @@ set -euo pipefail
 
 CACHE_DIR="${PGLAYERS_APT_CACHE_DIR:-/tmp/pglayers-apt-cache}"
 
-_pg_tag() { [ "$1" = "19" ] && echo "19beta3" || echo "$1"; }
+# Base-image Docker tag for a PG major -- resolved via the single source of
+# truth (scripts/pg-tag.sh) so the 19->19beta3 mapping lives in exactly one place.
+_pg_tag() { "$(dirname "$0")/pg-tag.sh" "$1"; }
 
 # Debian apt version -> clean, docker-tag-safe upstream version.
 # e.g. 0.8.5-1.pgdg13+1 -> 0.8.5 ; 3.6.4+dfsg-2.pgdg13+1 -> 3.6.4

--- a/scripts/detect-license.sh
+++ b/scripts/detect-license.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 pg="${1:?usage: detect-license.sh <pg> <apt_package>}"
 pkg="${2:?usage: detect-license.sh <pg> <apt_package>}"
-tag="$pg"; [ "$pg" = "19" ] && tag="19beta3"
+tag="$("$(dirname "$0")/pg-tag.sh" "$pg")"  # base-image tag via single source of truth
 
 # Fetch the whole copyright file once. Distinguish an infrastructure failure
 # (docker/apt error -> fail fast, non-zero) from a package that installs but

--- a/scripts/pg-tag.sh
+++ b/scripts/pg-tag.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+#
+# Single source of truth: map a PostgreSQL major version to its Docker Hub tag.
+#
+# A GA major's image tag is just the major ("postgres:17"), but a PRE-RELEASE
+# major has no bare tag yet -- Docker Hub publishes only pre-release tags
+# ("postgres:19beta3", later "19beta4", "19rc1", and finally the GA
+# "postgres:19"). Every consumer (Makefile, scripts, and the CI / base-image
+# workflows) resolves the tag through THIS script, so a tag roll is a one-line
+# edit here instead of a find-and-replace across the repo (the "PG 19 drift").
+#
+# When the pre-release tag rolls: change the 19) line below.
+# When the major goes GA:         delete the 19) line (it maps to itself).
+#
+# Usage: pg-tag.sh <pg-major>   # echoes the Docker tag for that major
+
+set -eu
+
+case "${1:?usage: pg-tag.sh <pg-major>}" in
+    19) echo "19beta3" ;;
+    *)  echo "$1" ;;
+esac


### PR DESCRIPTION
Implements the two follow-ups discussed after the base-image-monitor fixes (#62/#63/#65).

## A — Single source of truth for the PG-major → Docker-tag mapping

The `19 → 19beta3` mapping was copy-pasted in **5 files**; one stale copy (`ci.yml` on `19beta2`) was the "PG 19 drift" we fixed in #65. This removes the whole bug class:

- **`scripts/pg-tag.sh`** — the one place the mapping lives. Rolling the tag (`beta3→beta4→rc1`) or GA is a **one-line edit**.
- **`Makefile`** — `PG_TAG ?= $(shell ./scripts/pg-tag.sh $(PG))`; drops the `$(or $(PG_TAG),$(PG))` fallbacks and the `add-apt-ext` inline mapping. (Bonus: `make build PG=19` now works locally without passing `PG_TAG`.)
- **`scripts/apt-support.sh`, `scripts/detect-license.sh`** — call `pg-tag.sh`.
- **`ci.yml`** — the `matrix` job emits a `pg_tags` map (`{"17":"17","18":"18","19":"19beta3"}`) from `pg-tag.sh`; every build/test/profile job reads `fromJson(needs.matrix.outputs.pg_tags)[matrix.pg]` instead of the 8 hardcoded ternaries / `docker pull|tag` literals.
- **`monitor-base-image.yml`** — the check step calls `pg-tag.sh`.
- **`AGENTS.md`** — updated to name `pg-tag.sh` as the single source; the drift grep now excludes it (the only place the literal may appear).

## B — One rebuild path for base-image updates

Previously the monitor both opened the digest PR **and** fired a separate `workflow_dispatch` rebuild. Those two landed in the same `main` concurrency lane and the merge cancelled the dispatch mid-promote (the gap fixed in #65). This collapses to a single path:

- **`ci.yml`** — a change to `.github/base-image-digests.json` is now a full-rebuild trigger. The monitor's digest PR (which triggers `ci.yml` via the App token) **builds + tests every layer on the fresh base**; on auto-merge the `push` **promotes** them and rebuilds the profiles — exactly the normal build-once flow, gated by the PR's checks.
- **`monitor-base-image.yml`** — removes the `Trigger rebuild` dispatch step and the now-unused `actions: write` permission.

Benefits: no race/cancellation, correct ordering (promote only after the digest lands **and** the PR passed), and the base bump is validated **before** merge.

**Tradeoff:** a base bump now rebuilds **all** supported majors (`build_all`), not just the changed one. Correct — every layer sits on the changed base — and it's the same cost the old dispatch incurred when multiple majors changed; just always-on and race-free.

## Validation
- `shellcheck` clean on all scripts; both workflows YAML-valid.
- Drift grep (`grep -rn '19beta\|19rc' Makefile scripts/ .github/ | grep -v -e base-image-digests.json -e scripts/pg-tag.sh`) prints **nothing**.
- `make` dry-runs: `PG=19 → PG_TAG=19beta3`, `PG=17 → 17`, explicit `PG_TAG=` override respected.
- `pg_tags` jq map verified: `{"17":"17","18":"18","19":"19beta3"}`.

Touches `ci.yml`, so the full matrix + `Test PG 17` run here — merges normally.